### PR TITLE
Prefix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
+PROPINQUITY_OUT_DIR ?= .
+export PROPINQUITY_OUT_DIR
+
 COLLECTIONS_ROOT := $(shell bin/config_checker.py --config=config --property=opentree.collections)
 export COLLECTIONS_ROOT
 
@@ -24,51 +27,53 @@ export PHYLESYSTEM_ROOT
 SYNTHESIS_COLLECTIONS := $(shell bin/config_checker.py --config=config --property=synthesis.collections)
 export SYNTHESIS_COLLECTIONS
 
-INPUT_PHYLO_ARTIFACTS=phylo_input/studies.txt \
-                      phylo_input/study_tree_pairs.txt
+INPUT_PHYLO_ARTIFACTS=$(PROPINQUITY_OUT_DIR)/phylo_input/studies.txt \
+                      $(PROPINQUITY_OUT_DIR)/phylo_input/study_tree_pairs.txt
 
-ARTIFACTS=cleaned_ott/cleaned_ott.tre \
-	  cleaned_phylo/phylo_inputs_cleaned.txt \
-	  exemplified_phylo/nonempty_trees.txt \
-	  subproblems/subproblem-ids.txt \
-	  grafted_solution/grafted_solution_ottnames.tre \
-	  full_supertree/full_supertree.tre \
-	  labelled_supertree/labelled_supertree.tre \
-	  labelled_supertree_ottnames/labelled_supertree_ottnames.tre \
-	  annotated_supertree/annotations.json
+ARTIFACTS=$(PROPINQUITY_OUT_DIR)/cleaned_ott/cleaned_ott.tre \
+	  $(PROPINQUITY_OUT_DIR)/cleaned_phylo/phylo_inputs_cleaned.txt \
+	  $(PROPINQUITY_OUT_DIR)/exemplified_phylo/nonempty_trees.txt \
+	  $(PROPINQUITY_OUT_DIR)/subproblems/subproblem-ids.txt \
+	  $(PROPINQUITY_OUT_DIR)/grafted_solution/grafted_solution_ottnames.tre \
+	  $(PROPINQUITY_OUT_DIR)/full_supertree/full_supertree.tre \
+	  $(PROPINQUITY_OUT_DIR)/labelled_supertree/labelled_supertree.tre \
+	  $(PROPINQUITY_OUT_DIR)/labelled_supertree_ottnames/labelled_supertree_ottnames.tre \
+	  $(PROPINQUITY_OUT_DIR)/annotated_supertree/annotations.json
 
-ASSESSMENT_ARTIFACTS = assessments/supertree_degree_distribution.txt \
-	assessments/taxonomy_degree_distribution.txt \
-	assessments/lost_taxa.txt \
-	assessments/summary.json
+ASSESSMENT_ARTIFACTS = $(PROPINQUITY_OUT_DIR)/assessments/supertree_degree_distribution.txt \
+	$(PROPINQUITY_OUT_DIR)/assessments/taxonomy_degree_distribution.txt \
+	$(PROPINQUITY_OUT_DIR)/assessments/lost_taxa.txt \
+	$(PROPINQUITY_OUT_DIR)/assessments/summary.json
 
-HTML_ARTIFACTS = annotated_supertree/index.html \
-	annotated_supertree/index.json \
-	assessments/index.html \
-	cleaned_ott/index.html \
-	cleaned_ott/index.json \
-	cleaned_phylo/index.json \
-	cleaned_phylo/index.html \
-	exemplified_phylo/index.html \
-	exemplified_phylo/index.json \
-	grafted_solution/index.html \
-	grafted_solution/index.json \
-	index.html \
-	index.json \
-	labelled_supertree/index.html \
-	labelled_supertree/index.json \
-	phylo_input/index.json \
-	phylo_input/index.html \
-	subproblems/index.html \
-	subproblems/index.json \
-	subproblem_solutions/index.html \
-	subproblem_solutions/index.json \
-	phylo_snapshot/index.html \
-	phylo_snapshot/index.json \
+HTML_ARTIFACTS = $(PROPINQUITY_OUT_DIR)/annotated_supertree/index.html \
+	$(PROPINQUITY_OUT_DIR)/annotated_supertree/index.json \
+	$(PROPINQUITY_OUT_DIR)/assessments/index.html \
+	$(PROPINQUITY_OUT_DIR)/cleaned_ott/index.html \
+	$(PROPINQUITY_OUT_DIR)/cleaned_ott/index.json \
+	$(PROPINQUITY_OUT_DIR)/cleaned_phylo/index.json \
+	$(PROPINQUITY_OUT_DIR)/cleaned_phylo/index.html \
+	$(PROPINQUITY_OUT_DIR)/exemplified_phylo/index.html \
+	$(PROPINQUITY_OUT_DIR)/exemplified_phylo/index.json \
+	$(PROPINQUITY_OUT_DIR)/grafted_solution/index.html \
+	$(PROPINQUITY_OUT_DIR)/grafted_solution/index.json \
+	$(PROPINQUITY_OUT_DIR)/index.html \
+	$(PROPINQUITY_OUT_DIR)/index.json \
+	$(PROPINQUITY_OUT_DIR)/labelled_supertree/index.html \
+	$(PROPINQUITY_OUT_DIR)/labelled_supertree/index.json \
+	$(PROPINQUITY_OUT_DIR)/phylo_input/index.json \
+	$(PROPINQUITY_OUT_DIR)/phylo_input/index.html \
+	$(PROPINQUITY_OUT_DIR)/subproblems/index.html \
+	$(PROPINQUITY_OUT_DIR)/subproblems/index.json \
+	$(PROPINQUITY_OUT_DIR)/subproblem_solutions/index.html \
+	$(PROPINQUITY_OUT_DIR)/subproblem_solutions/index.json \
+	$(PROPINQUITY_OUT_DIR)/phylo_snapshot/index.html \
+	$(PROPINQUITY_OUT_DIR)/phylo_snapshot/index.json \
 
-all: labelled_supertree/labelled_supertree.tre annotated_supertree/annotations.json
+all: $(PROPINQUITY_OUT_DIR)/labelled_supertree/labelled_supertree.tre \
+	 $(PROPINQUITY_OUT_DIR)/annotated_supertree/annotations.json
 
-extra: labelled_supertree/labelled_supertree_ottnames.tre grafted_supertree/grafted_supertree_ottnames.tre
+extra: $(PROPINQUITY_OUT_DIR)/labelled_supertree/labelled_supertree_ottnames.tre \
+	   $(PROPINQUITY_OUT_DIR)/grafted_supertree/grafted_supertree_ottnames.tre
 
 clean: clean1 clean2
 	rm -f $(ARTIFACTS)
@@ -80,39 +85,45 @@ include Makefile.clean_inputs
 include Makefile.subproblems
 
 
-assessments/supertree_degree_distribution.txt: labelled_supertree/labelled_supertree.tre
-	otc-degree-distribution labelled_supertree/labelled_supertree.tre > assessments/supertree_degree_distribution.txt
+$(PROPINQUITY_OUT_DIR)/assessments/supertree_degree_distribution.txt: $(PROPINQUITY_OUT_DIR)/labelled_supertree/labelled_supertree.tre
+	@if ! test -d $(PROPINQUITY_OUT_DIR)/assessments ; then mkdir -p $(PROPINQUITY_OUT_DIR)/assessments ; fi
+	otc-degree-distribution \
+		$(PROPINQUITY_OUT_DIR)/labelled_supertree/labelled_supertree.tre \
+		> $(PROPINQUITY_OUT_DIR)/assessments/supertree_degree_distribution.txt
 
-assessments/taxonomy_degree_distribution.txt: cleaned_ott/cleaned_ott.tre
-	otc-degree-distribution cleaned_ott/cleaned_ott.tre > assessments/taxonomy_degree_distribution.txt
+$(PROPINQUITY_OUT_DIR)/assessments/taxonomy_degree_distribution.txt: $(PROPINQUITY_OUT_DIR)/cleaned_ott/cleaned_ott.tre
+	@if ! test -d $(PROPINQUITY_OUT_DIR)/assessments ; then mkdir -p $(PROPINQUITY_OUT_DIR)/assessments ; fi
+	otc-degree-distribution $(PROPINQUITY_OUT_DIR)/cleaned_ott/cleaned_ott.tre > $(PROPINQUITY_OUT_DIR)/assessments/taxonomy_degree_distribution.txt
 
-assessments/lost_taxa.txt: labelled_supertree/labelled_supertree.tre
+$(PROPINQUITY_OUT_DIR)/assessments/lost_taxa.txt: $(PROPINQUITY_OUT_DIR)/labelled_supertree/labelled_supertree.tre
+	@if ! test -d $(PROPINQUITY_OUT_DIR)/assessments ; then mkdir -p $(PROPINQUITY_OUT_DIR)/assessments ; fi
 	otc-taxonomy-parser \
 	  $$(./bin/config_checker.py \
 	  --config=config \
 	  --property=opentree.ott) \
 	  --report-lost-taxa \
-	  labelled_supertree/labelled_supertree.tre \
-	  -c config > assessments/lost_taxa.txt
+	  $(PROPINQUITY_OUT_DIR)/labelled_supertree/labelled_supertree.tre \
+	  -c config > $(PROPINQUITY_OUT_DIR)/assessments/lost_taxa.txt
 
-assessments/summary.json: annotated_supertree/annotations.json \
-						  assessments/taxonomy_degree_distribution.txt \
-	                      assessments/supertree_degree_distribution.txt \
-	                      assessments/lost_taxa.txt
-	@rm -f assessments/summary.json 2>/dev/null
-	./bin/run_assessments.py . assessments/summary.json 2>&1 | tee assessments/log.txt || true
-	@ls assessments/summary.json >/dev/null
+$(PROPINQUITY_OUT_DIR)/assessments/summary.json: $(PROPINQUITY_OUT_DIR)/annotated_supertree/annotations.json \
+						  $(PROPINQUITY_OUT_DIR)/assessments/taxonomy_degree_distribution.txt \
+	                      $(PROPINQUITY_OUT_DIR)/assessments/supertree_degree_distribution.txt \
+	                      $(PROPINQUITY_OUT_DIR)/assessments/lost_taxa.txt
+	@if ! test -d $(PROPINQUITY_OUT_DIR)/assessments ; then mkdir -p $(PROPINQUITY_OUT_DIR)/assessments ; fi
+	@rm -f $(PROPINQUITY_OUT_DIR)/assessments/summary.json 2>/dev/null
+	./bin/run_assessments.py $(PROPINQUITY_OUT_DIR) $(PROPINQUITY_OUT_DIR)/assessments/summary.json 2>&1 | tee $(PROPINQUITY_OUT_DIR)/assessments/log.txt || true
+	@ls $(PROPINQUITY_OUT_DIR)/assessments/summary.json >/dev/null
 
 
-check: assessments/summary.json
-	@if grep '"ERROR"' assessments/summary.json >/dev/null 2>/dev/null ; \
-		then cat assessments/summary.json && echo 'Errors found' && false ; \
-		else echo 'OK. Checks passed. A quirky listing of checks is in assessments/summary.json'; \
+check: $(PROPINQUITY_OUT_DIR)/assessments/summary.json
+	@if grep '"ERROR"' $(PROPINQUITY_OUT_DIR)/assessments/summary.json >/dev/null 2>/dev/null ; \
+		then cat $(PROPINQUITY_OUT_DIR)/assessments/summary.json && echo 'Errors found' && false ; \
+		else echo "OK. Checks passed. A quirky listing of checks is in $(PROPINQUITY_OUT_DIR)/assessments/summary.json"; \
 		fi
 
-$(HTML_ARTIFACTS): assessments/summary.json
-	bin/document_outputs.py
+$(HTML_ARTIFACTS): $(PROPINQUITY_OUT_DIR)/assessments/summary.json
+	bin/document_outputs.py $(PROPINQUITY_OUT_DIR)
 	@echo 'Documentation created'
 
-html: assessments/summary.json assessments/index.html
-	@echo 'See index.html and linked files for documentation of output'
+html: $(PROPINQUITY_OUT_DIR)/assessments/summary.json $(PROPINQUITY_OUT_DIR)/assessments/index.html
+	@echo "See $(PROPINQUITY_OUT_DIR)/index.html and linked files for documentation of output"

--- a/Makefile.clean_inputs
+++ b/Makefile.clean_inputs
@@ -1,162 +1,191 @@
 CONFIG_FILENAME=config
 
-SUPPRESS_FLAG_ARTIFACTS=cleaned_ott/cleaned_ott.tre \
-	cleaned_ott/cleaned_ott.json \
-	cleaned_ott/ott_version.txt \
-	cleaned_ott/cleaning_flags.txt
+SUPPRESS_FLAG_ARTIFACTS=$(PROPINQUITY_OUT_DIR)/cleaned_ott/cleaned_ott.tre \
+	$(PROPINQUITY_OUT_DIR)/cleaned_ott/cleaned_ott.json \
+	$(PROPINQUITY_OUT_DIR)/cleaned_ott/ott_version.txt \
+	$(PROPINQUITY_OUT_DIR)/cleaned_ott/cleaning_flags.txt
 
-Makefile.clean_inputs: phylo_input/study_tree_pairs.txt
+Makefile.clean_inputs: $(PROPINQUITY_OUT_DIR)/phylo_input/study_tree_pairs.txt
 
 ARTIFACTS += $(SUPPRESS_FLAG_ARTIFACTS) \
-	phylo_snapshot/git_shas.txt \
-	phylo_snapshot/collections_git_shas.txt \
-	phylo_snapshot/concrete_rank_collection.json \
-	cleaned_ott/cleaning_flags.txt \
-	cleaned_ott/root_ott_id.txt \
-	cleaned_phylo/cleaning_flags.txt \
-	cleaned_phylo/root_ott_id.txt \
-	cleaned_phylo/phylo_inputs_cleaned.txt \
-	cleaned_phylo/needs_updating.txt \
-	exemplified_phylo/taxonomy.tre \
-	exemplified_phylo/args.txt \
-	exemplified_phylo/pruned_taxonomy_degree_distribution.txt \
-	phylo_induced_taxonomy/taxonomy.tre \
-	phylo_input/rank_collection.json \
-	phylo_input/collections.txt
+	$(PROPINQUITY_OUT_DIR)/phylo_snapshot/git_shas.txt \
+	$(PROPINQUITY_OUT_DIR)/phylo_snapshot/collections_git_shas.txt \
+	$(PROPINQUITY_OUT_DIR)/phylo_snapshot/concrete_rank_collection.json \
+	$(PROPINQUITY_OUT_DIR)/cleaned_ott/cleaning_flags.txt \
+	$(PROPINQUITY_OUT_DIR)/cleaned_ott/root_ott_id.txt \
+	$(PROPINQUITY_OUT_DIR)/cleaned_phylo/cleaning_flags.txt \
+	$(PROPINQUITY_OUT_DIR)/cleaned_phylo/root_ott_id.txt \
+	$(PROPINQUITY_OUT_DIR)/cleaned_phylo/phylo_inputs_cleaned.txt \
+	$(PROPINQUITY_OUT_DIR)/cleaned_phylo/needs_updating.txt \
+	$(PROPINQUITY_OUT_DIR)/exemplified_phylo/taxonomy.tre \
+	$(PROPINQUITY_OUT_DIR)/exemplified_phylo/args.txt \
+	$(PROPINQUITY_OUT_DIR)/exemplified_phylo/pruned_taxonomy_degree_distribution.txt \
+	$(PROPINQUITY_OUT_DIR)/phylo_induced_taxonomy/taxonomy.tre \
+	$(PROPINQUITY_OUT_DIR)/phylo_input/rank_collection.json \
+	$(PROPINQUITY_OUT_DIR)/phylo_input/collections.txt
 
 clean1:
-	rm -f cleaned_phylo/*.tre
-	rm -f cleaned_phylo/*.json
-	rm -f cleaned_phylo/needs_updating.txt
-	rm -f exemplified_phylo/*.tre
-	rm -f phylo_snapshot/*.json
-	rm -f phylo_snapshot/git_shas.txt
-	rm -f phylo_snapshot/collections_git_shas.txt
-	rm -f phylo_snapshot/stdouterr.txt
-	rm -f phylo_input/collections.txt
+	rm -f $(PROPINQUITY_OUT_DIR)/cleaned_phylo/*.tre
+	rm -f $(PROPINQUITY_OUT_DIR)/cleaned_phylo/*.json
+	rm -f $(PROPINQUITY_OUT_DIR)/cleaned_phylo/needs_updating.txt
+	rm -f $(PROPINQUITY_OUT_DIR)/exemplified_phylo/*.tre
+	rm -f $(PROPINQUITY_OUT_DIR)/phylo_snapshot/*.json
+	rm -f $(PROPINQUITY_OUT_DIR)/phylo_snapshot/git_shas.txt
+	rm -f $(PROPINQUITY_OUT_DIR)/phylo_snapshot/collections_git_shas.txt
+	rm -f $(PROPINQUITY_OUT_DIR)/phylo_snapshot/stdouterr.txt
+	rm -f $(PROPINQUITY_OUT_DIR)/phylo_input/collections.txt
 
 # "cleaned_ott" has dubious taxa pruned off. should check against treemachine and smasher versions
-cleaned_ott/root_ott_id.txt: $(CONFIG_FILENAME)
-	./bin/config_checker.py --config=$(CONFIG_FILENAME) --property=synthesis.root_ott_id > cleaned_ott/.raw_root_ott_id.txt
-	if ! diff cleaned_ott/.raw_root_ott_id.txt cleaned_ott/root_ott_id.txt 2>/dev/null; then mv cleaned_ott/.raw_root_ott_id.txt cleaned_ott/root_ott_id.txt ; fi
+$(PROPINQUITY_OUT_DIR)/cleaned_ott/root_ott_id.txt: $(CONFIG_FILENAME)
+	@if ! test -d $(PROPINQUITY_OUT_DIR)/cleaned_ott ; then mkdir -p $(PROPINQUITY_OUT_DIR)/cleaned_ott ; fi
+	./bin/config_checker.py --config=$(CONFIG_FILENAME) --property=synthesis.root_ott_id > $(PROPINQUITY_OUT_DIR)/cleaned_ott/.raw_root_ott_id.txt
+	if ! diff $(PROPINQUITY_OUT_DIR)/cleaned_ott/.raw_root_ott_id.txt $(PROPINQUITY_OUT_DIR)/cleaned_ott/root_ott_id.txt 2>/dev/null; then mv $(PROPINQUITY_OUT_DIR)/cleaned_ott/.raw_root_ott_id.txt $(PROPINQUITY_OUT_DIR)/cleaned_ott/root_ott_id.txt ; fi
 
-cleaned_ott/cleaning_flags.txt: $(CONFIG_FILENAME)
-	./bin/config_checker.py --config=$(CONFIG_FILENAME) --property=taxonomy.cleaning_flags > cleaned_ott/.raw_cleaning_flags.txt
-	if ! diff cleaned_ott/.raw_cleaning_flags.txt cleaned_ott/cleaning_flags.txt 2>/dev/null; then mv cleaned_ott/.raw_cleaning_flags.txt cleaned_ott/cleaning_flags.txt ; fi
+$(PROPINQUITY_OUT_DIR)/cleaned_ott/cleaning_flags.txt: $(CONFIG_FILENAME)
+	@if ! test -d $(PROPINQUITY_OUT_DIR)/cleaned_ott ; then mkdir -p $(PROPINQUITY_OUT_DIR)/cleaned_ott ; fi
+	./bin/config_checker.py --config=$(CONFIG_FILENAME) --property=taxonomy.cleaning_flags > $(PROPINQUITY_OUT_DIR)/cleaned_ott/.raw_cleaning_flags.txt
+	if ! diff $(PROPINQUITY_OUT_DIR)/cleaned_ott/.raw_cleaning_flags.txt $(PROPINQUITY_OUT_DIR)/cleaned_ott/cleaning_flags.txt 2>/dev/null; then mv $(PROPINQUITY_OUT_DIR)/cleaned_ott/.raw_cleaning_flags.txt $(PROPINQUITY_OUT_DIR)/cleaned_ott/cleaning_flags.txt ; fi
 
-cleaned_ott/ott_version.txt: $(OTT_DIR)/version.txt
-	if ! diff $(OTT_DIR)/version.txt cleaned_ott/ott_version.txt >/dev/null 2>&1 ; then cp $(OTT_DIR)/version.txt cleaned_ott/ott_version.txt ; fi
+$(PROPINQUITY_OUT_DIR)/cleaned_ott/ott_version.txt: $(OTT_DIR)/version.txt
+	@if ! test -d $(PROPINQUITY_OUT_DIR)/cleaned_ott ; then mkdir -p $(PROPINQUITY_OUT_DIR)/cleaned_ott ; fi
+	if ! diff $(OTT_DIR)/version.txt $(PROPINQUITY_OUT_DIR)/cleaned_ott/ott_version.txt >/dev/null 2>&1 ; then cp $(OTT_DIR)/version.txt $(PROPINQUITY_OUT_DIR)/cleaned_ott/ott_version.txt ; fi
 
-cleaned_ott/cleaned_ott.tre: $(OTT_FILEPATHS) cleaned_ott/ott_version.txt cleaned_ott/cleaning_flags.txt cleaned_ott/root_ott_id.txt
+$(PROPINQUITY_OUT_DIR)/cleaned_ott/cleaned_ott.tre: $(OTT_FILEPATHS) \
+													$(PROPINQUITY_OUT_DIR)/cleaned_ott/ott_version.txt \
+													$(PROPINQUITY_OUT_DIR)/cleaned_ott/cleaning_flags.txt \
+													$(PROPINQUITY_OUT_DIR)/cleaned_ott/root_ott_id.txt
 	$(PEYOTL_ROOT)/scripts/ott/suppress_by_flag.py \
 	    --ott-dir=$(OTT_DIR) \
-	    --output=cleaned_ott/cleaned_ott.tre \
-	    --log=cleaned_ott/cleaned_ott.json \
-	    --flags="$(shell cat cleaned_ott/cleaning_flags.txt)" \
-	    --root="$(shell cat cleaned_ott/root_ott_id.txt)"
+	    --output=$(PROPINQUITY_OUT_DIR)/cleaned_ott/cleaned_ott.tre \
+	    --log=$(PROPINQUITY_OUT_DIR)/cleaned_ott/cleaned_ott.json \
+	    --flags="$(shell cat $(PROPINQUITY_OUT_DIR)/cleaned_ott/cleaning_flags.txt)" \
+	    --root="$(shell cat $(PROPINQUITY_OUT_DIR)/cleaned_ott/root_ott_id.txt)"
 #    Maybe replace python program with C++ program below after we can generate the necessary log files.
 #	otc-taxonomy-parser $(OTT_DIR) --config=config -T > cleaned_ott/.raw_cleaned_ott.tre
 #	mv cleaned_ott/.raw_cleaned_ott.tre cleaned_ott/cleaned_ott.tre
 
-cleaned_ott/cleaned_ott.json: cleaned_ott/cleaned_ott.tre
+$(PROPINQUITY_OUT_DIR)/cleaned_ott/cleaned_ott.json: $(PROPINQUITY_OUT_DIR)/cleaned_ott/cleaned_ott.tre
 
-phylo_input/studies.txt: phylo_input/rank_collection.json
-	$(PEYOTL_ROOT)/scripts/collection_export.py --export=studyID phylo_input/rank_collection.json >phylo_input/studies.txt
+$(PROPINQUITY_OUT_DIR)/phylo_input/studies.txt: $(PROPINQUITY_OUT_DIR)/phylo_input/rank_collection.json
+	@if ! test -d $(PROPINQUITY_OUT_DIR)/phylo_input ; then mkdir -p $(PROPINQUITY_OUT_DIR)/phylo_input ; fi
+	$(PEYOTL_ROOT)/scripts/collection_export.py \
+		--export=studyID \
+		$(PROPINQUITY_OUT_DIR)/phylo_input/rank_collection.json \
+		 >$(PROPINQUITY_OUT_DIR)/phylo_input/studies.txt
 
-phylo_input/study_tree_pairs.txt: phylo_input/rank_collection.json
-	$(PEYOTL_ROOT)/scripts/collection_export.py --export=studyID_treeID phylo_input/rank_collection.json >phylo_input/study_tree_pairs.txt
+$(PROPINQUITY_OUT_DIR)/phylo_input/study_tree_pairs.txt: $(PROPINQUITY_OUT_DIR)/phylo_input/rank_collection.json
+	@if ! test -d $(PROPINQUITY_OUT_DIR)/phylo_input ; then mkdir -p $(PROPINQUITY_OUT_DIR)/phylo_input ; fi
+	$(PEYOTL_ROOT)/scripts/collection_export.py \
+		--export=studyID_treeID \
+		$(PROPINQUITY_OUT_DIR)/phylo_input/rank_collection.json \
+		>$(PROPINQUITY_OUT_DIR)/phylo_input/study_tree_pairs.txt
 
 # Snapshots of the NexSON are more efficient to produce in bulk (hence the export of the entire
 # collection as a part of the concrete_rank_collection target
-phylo_snapshot/git_shas.txt:
-	./bin/shard_shas.sh > .tmp_git_shas.txt
-	if ! diff phylo_snapshot/git_shas.txt .tmp_git_shas.txt >/dev/null 2>&1 ; then mv .tmp_git_shas.txt phylo_snapshot/git_shas.txt ; else rm .tmp_git_shas.txt ; fi
+$(PROPINQUITY_OUT_DIR)/phylo_snapshot/git_shas.txt:
+	@if ! test -d $(PROPINQUITY_OUT_DIR)/phylo_snapshot ; then mkdir -p $(PROPINQUITY_OUT_DIR)/phylo_snapshot ; fi
+	./bin/shard_shas.sh > $(PROPINQUITY_OUT_DIR)/.tmp_git_shas.txt
+	if ! diff $(PROPINQUITY_OUT_DIR)/phylo_snapshot/git_shas.txt $(PROPINQUITY_OUT_DIR)/.tmp_git_shas.txt >/dev/null 2>&1 ; then mv $(PROPINQUITY_OUT_DIR)/.tmp_git_shas.txt $(PROPINQUITY_OUT_DIR)/phylo_snapshot/git_shas.txt ; else rm $(PROPINQUITY_OUT_DIR)/.tmp_git_shas.txt ; fi
 
 
-phylo_snapshot/collections_git_shas.txt:
-	./bin/collections_shard_shas.sh > .tmp_collections_git_shas.txt
-	if ! diff phylo_snapshot/git_shas.txt .tmp_collections_git_shas.txt >/dev/null 2>&1 ; then mv .tmp_collections_git_shas.txt phylo_snapshot/collections_git_shas.txt ; else rm .tmp_collections_git_shas.txt ; fi
+$(PROPINQUITY_OUT_DIR)/phylo_snapshot/collections_git_shas.txt:
+	@if ! test -d $(PROPINQUITY_OUT_DIR)/phylo_snapshot ; then mkdir -p $(PROPINQUITY_OUT_DIR)/phylo_snapshot ; fi
+	./bin/collections_shard_shas.sh > $(PROPINQUITY_OUT_DIR)/.tmp_collections_git_shas.txt
+	if ! diff $(PROPINQUITY_OUT_DIR)/phylo_snapshot/git_shas.txt $(PROPINQUITY_OUT_DIR)/.tmp_collections_git_shas.txt >/dev/null 2>&1 ; then mv $(PROPINQUITY_OUT_DIR)/.tmp_collections_git_shas.txt $(PROPINQUITY_OUT_DIR)/phylo_snapshot/collections_git_shas.txt ; else rm $(PROPINQUITY_OUT_DIR)/.tmp_collections_git_shas.txt ; fi
 
-
-phylo_snapshot/concrete_rank_collection.json: phylo_snapshot/git_shas.txt phylo_input/rank_collection.json
+$(PROPINQUITY_OUT_DIR)/phylo_snapshot/concrete_rank_collection.json: $(PROPINQUITY_OUT_DIR)/phylo_snapshot/git_shas.txt phylo_input/rank_collection.json
+	@if ! test -d $(PROPINQUITY_OUT_DIR)/phylo_snapshot ; then mkdir -p $(PROPINQUITY_OUT_DIR)/phylo_snapshot ; fi
 	$(PEYOTL_ROOT)/scripts/phylesystem/export_studies_from_collection.py \
 	  --phylesystem-par=$(PHYLESYSTEM_ROOT)/shards \
-	  --output-dir=phylo_snapshot \
-	  phylo_input/rank_collection.json \
-	  -v 2>&1 | tee phylo_snapshot/stdouterr.txt
+	  --output-dir=$(PROPINQUITY_OUT_DIR)/phylo_snapshot \
+	  $(PROPINQUITY_OUT_DIR)/phylo_input/rank_collection.json \
+	  -v 2>&1 | tee $(PROPINQUITY_OUT_DIR)/phylo_snapshot/stdouterr.txt
 
-# phylo_snapshot/pg_%.json:  phylo_snapshot/git_shas.txt phylo_snapshot/concrete_rank_collection.json
-# 	$(PEYOTL_ROOT)/scripts/phylesystem/export_studies_from_collection.py \
-# 	  --phylesystem-par=$(PHYLESYSTEM_ROOT)/shards \
-# 	  --output-dir=phylo_snapshot \
-# 	  --select="$(shell basename $@)" \
-# 	  phylo_input/rank_collection.json \
-# 	  -v 2>&1 | tee -a phylo_snapshot/stdouterr.txt
-
-# phylo_snapshot/ot_%.json:  phylo_snapshot/git_shas.txt phylo_snapshot/concrete_rank_collection.json
-# 	$(PEYOTL_ROOT)/scripts/phylesystem/export_studies_from_collection.py \
-# 	  --phylesystem-par=$(PHYLESYSTEM_ROOT)/shards \
-# 	  --output-dir=phylo_snapshot \
-# 	  --select="$(shell basename $@)" \
-# 	  phylo_input/rank_collection.json \
-# 	  -v 2>&1 | tee -a phylo_snapshot/stdouterr.txt
-
-cleaned_phylo/needs_updating.txt: phylo_input/study_tree_pairs.txt cleaned_ott/cleaning_flags.txt cleaned_ott/root_ott_id.txt
-	if ! diff cleaned_ott/cleaning_flags.txt cleaned_phylo/cleaning_flags.txt >/dev/null 2>&1 && \
-	   ! diff cleaned_ott/root_ott_id.txt cleaned_phylo/root_ott_id.txt >/dev/null 2>&1 ; \
+$(PROPINQUITY_OUT_DIR)/cleaned_phylo/needs_updating.txt: $(PROPINQUITY_OUT_DIR)/phylo_input/study_tree_pairs.txt \
+														 $(PROPINQUITY_OUT_DIR)/cleaned_ott/cleaning_flags.txt \
+														 $(PROPINQUITY_OUT_DIR)/cleaned_ott/root_ott_id.txt
+	@if ! test -d $(PROPINQUITY_OUT_DIR)/cleaned_phylo ; then mkdir -p $(PROPINQUITY_OUT_DIR)/cleaned_phylo ; fi
+	if ! diff $(PROPINQUITY_OUT_DIR)/cleaned_ott/cleaning_flags.txt $(PROPINQUITY_OUT_DIR)/cleaned_phylo/cleaning_flags.txt >/dev/null 2>&1 && \
+	   ! diff $(PROPINQUITY_OUT_DIR)/cleaned_ott/root_ott_id.txt $(PROPINQUITY_OUT_DIR)/cleaned_phylo/root_ott_id.txt >/dev/null 2>&1 ; \
 	then \
-		sed -e 's:\(.*\):phylo_snapshot/\1.json:' < phylo_input/study_tree_pairs.txt > cleaned_phylo/x ; \
-		bin/convert-space-to-newline cleaned_phylo/x > cleaned_phylo/needs_updating.txt ;\
-		rm -f cleaned_phylo/x ;\
+		sed -e 's:\(.*\):phylo_snapshot/\1.json:' < $(PROPINQUITY_OUT_DIR)/phylo_input/study_tree_pairs.txt > $(PROPINQUITY_OUT_DIR)/cleaned_phylo/x ; \
+		bin/convert-space-to-newline $(PROPINQUITY_OUT_DIR)/cleaned_phylo/x > $(PROPINQUITY_OUT_DIR)/cleaned_phylo/needs_updating.txt ;\
+		rm -f $(PROPINQUITY_OUT_DIR)/cleaned_phylo/x ;\
 	else \
-		./bin/write-needs-updating cleaned_phylo $$(sed -e 's:\(.*\):phylo_snapshot/\1.json:' < phylo_input/study_tree_pairs.txt) > cleaned_phylo/needs_updating.txt ;\
+		./bin/write-needs-updating $(PROPINQUITY_OUT_DIR)/cleaned_phylo $$(sed -e 's:\(.*\):phylo_snapshot/\1.json:' < $(PROPINQUITY_OUT_DIR)/phylo_input/study_tree_pairs.txt) > $(PROPINQUITY_OUT_DIR)/cleaned_phylo/needs_updating.txt ;\
 	fi
-	cp cleaned_ott/cleaning_flags.txt cleaned_phylo/cleaning_flags.txt
-	cp cleaned_ott/root_ott_id.txt cleaned_phylo/root_ott_id.txt
+	cp $(PROPINQUITY_OUT_DIR)/cleaned_ott/cleaning_flags.txt $(PROPINQUITY_OUT_DIR)/cleaned_phylo/cleaning_flags.txt
+	cp $(PROPINQUITY_OUT_DIR)/cleaned_ott/root_ott_id.txt $(PROPINQUITY_OUT_DIR)/cleaned_phylo/root_ott_id.txt
 
 # Could we make the cleaned_phylo/*.tre files depend on INDIVIDUAL phylo_snapshot/*.json files?
-cleaned_phylo/phylo_inputs_cleaned.txt: cleaned_phylo/needs_updating.txt cleaned_ott/cleaning_flags.txt cleaned_ott/root_ott_id.txt phylo_snapshot/concrete_rank_collection.json $(OTT_FILEPATHS)
+$(PROPINQUITY_OUT_DIR)/cleaned_phylo/phylo_inputs_cleaned.txt: $(PROPINQUITY_OUT_DIR)/cleaned_phylo/needs_updating.txt \
+															   $(PROPINQUITY_OUT_DIR)/cleaned_ott/cleaning_flags.txt \
+															   $(PROPINQUITY_OUT_DIR)/cleaned_ott/root_ott_id.txt \
+															   $(PROPINQUITY_OUT_DIR)/phylo_snapshot/concrete_rank_collection.json \
+															   $(OTT_FILEPATHS)
+	@if ! test -d $(PROPINQUITY_OUT_DIR)/cleaned_phylo ; then mkdir -p $(PROPINQUITY_OUT_DIR)/cleaned_phylo ; fi
 	$(PEYOTL_ROOT)/scripts/nexson/prune_to_clean_mapped.py \
 	  --ott-dir=$(OTT_DIR) \
-	  --input-files-list=cleaned_phylo/needs_updating.txt \
-	  --out-dir=cleaned_phylo \
-	  --ott-prune-flags="$(shell cat cleaned_ott/cleaning_flags.txt)" \
-	  --root="$(shell cat cleaned_ott/root_ott_id.txt)"
-	touch cleaned_phylo/phylo_inputs_cleaned.txt
+	  --input-files-list=$(PROPINQUITY_OUT_DIR)/cleaned_phylo/needs_updating.txt \
+	  --out-dir=$(PROPINQUITY_OUT_DIR)/cleaned_phylo \
+	  --ott-prune-flags="$(shell cat $(PROPINQUITY_OUT_DIR)/cleaned_ott/cleaning_flags.txt)" \
+	  --root="$(shell cat $(PROPINQUITY_OUT_DIR)/cleaned_ott/root_ott_id.txt)"
+	touch $(PROPINQUITY_OUT_DIR)/cleaned_phylo/phylo_inputs_cleaned.txt
 
-# cleaned_phylo/%.tre: phylo_snapshot/%.json cleaned_ott/cleaning_flags.txt
-# 	$(PEYOTL_ROOT)/scripts/nexson/prune_to_clean_mapped.py \
-# 	  --ott-dir=$(OTT_DIR) \
-# 	  --out-dir=cleaned_phylo \
-# 	  --ott-prune-flags="$(shell cat cleaned_ott/cleaning_flags.txt)" \
-# 	  $<
-
-exemplified_phylo/args.txt : phylo_input/study_tree_pairs.txt 
-	sed -e 's:\(.*\):cleaned_phylo/\1.tre:' phylo_input/study_tree_pairs.txt > exemplified_phylo/args.txt
+$(PROPINQUITY_OUT_DIR)/exemplified_phylo/args.txt : $(PROPINQUITY_OUT_DIR)/phylo_input/study_tree_pairs.txt 
+	@if ! test -d $(PROPINQUITY_OUT_DIR)/exemplified_phylo ; then mkdir -p $(PROPINQUITY_OUT_DIR)/exemplified_phylo ; fi
+	sed -e "s:\(.*\):$(PROPINQUITY_OUT_DIR)/cleaned_phylo/\1.tre:" $(PROPINQUITY_OUT_DIR)/phylo_input/study_tree_pairs.txt > $(PROPINQUITY_OUT_DIR)/exemplified_phylo/args.txt
 
 # Could we make the exemplified_phylo/*.tre files depend on INDIVIDUAL cleaned_phylo/*.tre files?
-exemplified_phylo/nonempty_trees.txt : exemplified_phylo/args.txt cleaned_ott/cleaned_ott.tre cleaned_phylo/phylo_inputs_cleaned.txt
+$(PROPINQUITY_OUT_DIR)/exemplified_phylo/nonempty_trees.txt : $(PROPINQUITY_OUT_DIR)/exemplified_phylo/args.txt \
+															  $(PROPINQUITY_OUT_DIR)/cleaned_ott/cleaned_ott.tre \
+															  $(PROPINQUITY_OUT_DIR)/cleaned_phylo/phylo_inputs_cleaned.txt
+	@if ! test -d $(PROPINQUITY_OUT_DIR)/exemplified_phylo ; then mkdir -p $(PROPINQUITY_OUT_DIR)/exemplified_phylo ; fi
 	otc-nonterminals-to-exemplars \
-	  -eexemplified_phylo \
-	  cleaned_ott/cleaned_ott.tre \
-	  -fexemplified_phylo/args.txt \
-	  -jexemplified_phylo/exemplified_log.json \
-	  -nexemplified_phylo/.nonempty_trees.txt && mv exemplified_phylo/.nonempty_trees.txt exemplified_phylo/nonempty_trees.txt
+	  -e$(PROPINQUITY_OUT_DIR)/exemplified_phylo \
+	  $(PROPINQUITY_OUT_DIR)/cleaned_ott/cleaned_ott.tre \
+	  -f$(PROPINQUITY_OUT_DIR)/exemplified_phylo/args.txt \
+	  -j$(PROPINQUITY_OUT_DIR)/exemplified_phylo/exemplified_log.json \
+	  -n$(PROPINQUITY_OUT_DIR)/exemplified_phylo/.nonempty_trees.txt && mv \
+	  $(PROPINQUITY_OUT_DIR)/exemplified_phylo/.nonempty_trees.txt \
+	  $(PROPINQUITY_OUT_DIR)/exemplified_phylo/nonempty_trees.txt
 
-exemplified_phylo/taxonomy.tre: exemplified_phylo/nonempty_trees.txt
+$(PROPINQUITY_OUT_DIR)/exemplified_phylo/taxonomy.tre: $(PROPINQUITY_OUT_DIR)/exemplified_phylo/nonempty_trees.txt
 
-exemplified_phylo/pruned_taxonomy_degree_distribution.txt : exemplified_phylo/taxonomy.tre
-	otc-degree-distribution exemplified_phylo/taxonomy.tre > exemplified_phylo/pruned_taxonomy_degree_distribution.txt
+$(PROPINQUITY_OUT_DIR)/exemplified_phylo/pruned_taxonomy_degree_distribution.txt : $(PROPINQUITY_OUT_DIR)/exemplified_phylo/taxonomy.tre
+	@if ! test -d $(PROPINQUITY_OUT_DIR)/exemplified_phylo ; then mkdir -p $(PROPINQUITY_OUT_DIR)/exemplified_phylo ; fi
+	otc-degree-distribution \
+		$(PROPINQUITY_OUT_DIR)/exemplified_phylo/taxonomy.tre \
+		> $(PROPINQUITY_OUT_DIR)/exemplified_phylo/pruned_taxonomy_degree_distribution.txt
 
-phylo_induced_taxonomy/taxonomy.tre : exemplified_phylo/taxonomy.tre
-	ln -s ../exemplified_phylo/taxonomy.tre phylo_induced_taxonomy/taxonomy.tre
+$(PROPINQUITY_OUT_DIR)/phylo_induced_taxonomy/taxonomy.tre : $(PROPINQUITY_OUT_DIR)/exemplified_phylo/taxonomy.tre
+	@if ! test -d $(PROPINQUITY_OUT_DIR)/phylo_induced_taxonomy ; then mkdir -p $(PROPINQUITY_OUT_DIR)/phylo_induced_taxonomy ; fi
+	ln -s $(PROPINQUITY_OUT_DIR)/exemplified_phylo/taxonomy.tre $(PROPINQUITY_OUT_DIR)/phylo_induced_taxonomy/taxonomy.tre
 
 # phylo_input holds the lists of study+tree pairs to be used during the supertree construction
-phylo_input/collections.txt: config
-	bin/config_checker.py --config=config --property=synthesis.collections > phylo_input/.raw_collections.txt
-	if ! diff phylo_input/collections.txt phylo_input/.raw_collections.txt 2>/dev/null ; then mv phylo_input/.raw_collections.txt phylo_input/collections.txt ; else rm phylo_input/.raw_collections.txt ; fi
+$(PROPINQUITY_OUT_DIR)/phylo_input/collections.txt: config
+	@if ! test -d $(PROPINQUITY_OUT_DIR)/phylo_input ; then mkdir -p $(PROPINQUITY_OUT_DIR)/phylo_input ; fi
+	bin/config_checker.py --config=config --property=synthesis.collections > $(PROPINQUITY_OUT_DIR)/phylo_input/.raw_collections.txt
+	if ! diff \
+			$(PROPINQUITY_OUT_DIR)/phylo_input/collections.txt \
+			$(PROPINQUITY_OUT_DIR)/phylo_input/.raw_collections.txt 2>/dev/null ; \
+	then \
+		mv $(PROPINQUITY_OUT_DIR)/phylo_input/.raw_collections.txt \
+		$(PROPINQUITY_OUT_DIR)/phylo_input/collections.txt ; \
+	else rm $(PROPINQUITY_OUT_DIR)/phylo_input/.raw_collections.txt ; \
+	fi
 
-phylo_input/rank_collection.json: phylo_input/collections.txt $(addsuffix .json, $(addprefix $(COLLECTIONS_ROOT)/shards/collections-1/collections-by-owner/, $(SYNTHESIS_COLLECTIONS)))
-	cd phylo_input ; \
-	../bin/reaggregate-synth-collections.sh .raw_rank_collection.json
-	if ! diff phylo_input/rank_collection.json phylo_input/.raw_rank_collection.json 2>/dev/null ; then mv phylo_input/.raw_rank_collection.json phylo_input/rank_collection.json ; else rm phylo_input/.raw_rank_collection.json ; fi
+$(PROPINQUITY_OUT_DIR)/phylo_input/rank_collection.json: $(PROPINQUITY_OUT_DIR)/phylo_input/collections.txt \
+													     $(addsuffix .json, $(addprefix $(COLLECTIONS_ROOT)/shards/collections-1/collections-by-owner/, $(SYNTHESIS_COLLECTIONS)))
+	@if ! test -d $(PROPINQUITY_OUT_DIR)/phylo_input ; then mkdir -p $(PROPINQUITY_OUT_DIR)/phylo_input ; fi
+	bin/reaggregate-synth-collections.sh $(PROPINQUITY_OUT_DIR)/phylo_input/.raw_rank_collection.json
+	if ! diff \
+			$(PROPINQUITY_OUT_DIR)/phylo_input/rank_collection.json \
+			$(PROPINQUITY_OUT_DIR)/phylo_input/.raw_rank_collection.json \
+			2>/dev/null ; \
+	then \
+		mv $(PROPINQUITY_OUT_DIR)/phylo_input/.raw_rank_collection.json \
+		   $(PROPINQUITY_OUT_DIR)/phylo_input/rank_collection.json ; \
+	else \
+		rm $(PROPINQUITY_OUT_DIR)/phylo_input/.raw_rank_collection.json ; \
+	fi

--- a/Makefile.clean_inputs
+++ b/Makefile.clean_inputs
@@ -93,7 +93,8 @@ $(PROPINQUITY_OUT_DIR)/phylo_snapshot/collections_git_shas.txt:
 	./bin/collections_shard_shas.sh > $(PROPINQUITY_OUT_DIR)/.tmp_collections_git_shas.txt
 	if ! diff $(PROPINQUITY_OUT_DIR)/phylo_snapshot/git_shas.txt $(PROPINQUITY_OUT_DIR)/.tmp_collections_git_shas.txt >/dev/null 2>&1 ; then mv $(PROPINQUITY_OUT_DIR)/.tmp_collections_git_shas.txt $(PROPINQUITY_OUT_DIR)/phylo_snapshot/collections_git_shas.txt ; else rm $(PROPINQUITY_OUT_DIR)/.tmp_collections_git_shas.txt ; fi
 
-$(PROPINQUITY_OUT_DIR)/phylo_snapshot/concrete_rank_collection.json: $(PROPINQUITY_OUT_DIR)/phylo_snapshot/git_shas.txt phylo_input/rank_collection.json
+$(PROPINQUITY_OUT_DIR)/phylo_snapshot/concrete_rank_collection.json: $(PROPINQUITY_OUT_DIR)/phylo_snapshot/git_shas.txt \
+																	 $(PROPINQUITY_OUT_DIR)/phylo_input/rank_collection.json
 	@if ! test -d $(PROPINQUITY_OUT_DIR)/phylo_snapshot ; then mkdir -p $(PROPINQUITY_OUT_DIR)/phylo_snapshot ; fi
 	$(PEYOTL_ROOT)/scripts/phylesystem/export_studies_from_collection.py \
 	  --phylesystem-par=$(PHYLESYSTEM_ROOT)/shards \
@@ -108,7 +109,7 @@ $(PROPINQUITY_OUT_DIR)/cleaned_phylo/needs_updating.txt: $(PROPINQUITY_OUT_DIR)/
 	if ! diff $(PROPINQUITY_OUT_DIR)/cleaned_ott/cleaning_flags.txt $(PROPINQUITY_OUT_DIR)/cleaned_phylo/cleaning_flags.txt >/dev/null 2>&1 && \
 	   ! diff $(PROPINQUITY_OUT_DIR)/cleaned_ott/root_ott_id.txt $(PROPINQUITY_OUT_DIR)/cleaned_phylo/root_ott_id.txt >/dev/null 2>&1 ; \
 	then \
-		sed -e 's:\(.*\):phylo_snapshot/\1.json:' < $(PROPINQUITY_OUT_DIR)/phylo_input/study_tree_pairs.txt > $(PROPINQUITY_OUT_DIR)/cleaned_phylo/x ; \
+		sed -e "s:\(.*\):$(PROPINQUITY_OUT_DIR)/phylo_snapshot/\1.json:" < $(PROPINQUITY_OUT_DIR)/phylo_input/study_tree_pairs.txt > $(PROPINQUITY_OUT_DIR)/cleaned_phylo/x ; \
 		bin/convert-space-to-newline $(PROPINQUITY_OUT_DIR)/cleaned_phylo/x > $(PROPINQUITY_OUT_DIR)/cleaned_phylo/needs_updating.txt ;\
 		rm -f $(PROPINQUITY_OUT_DIR)/cleaned_phylo/x ;\
 	else \

--- a/Makefile.clean_inputs
+++ b/Makefile.clean_inputs
@@ -1,5 +1,3 @@
-CONFIG_FILENAME=config
-
 SUPPRESS_FLAG_ARTIFACTS=$(PROPINQUITY_OUT_DIR)/cleaned_ott/cleaned_ott.tre \
 	$(PROPINQUITY_OUT_DIR)/cleaned_ott/cleaned_ott.json \
 	$(PROPINQUITY_OUT_DIR)/cleaned_ott/ott_version.txt \
@@ -61,7 +59,7 @@ $(PROPINQUITY_OUT_DIR)/cleaned_ott/cleaned_ott.tre: $(OTT_FILEPATHS) \
 	    --flags="$(shell cat $(PROPINQUITY_OUT_DIR)/cleaned_ott/cleaning_flags.txt)" \
 	    --root="$(shell cat $(PROPINQUITY_OUT_DIR)/cleaned_ott/root_ott_id.txt)"
 #    Maybe replace python program with C++ program below after we can generate the necessary log files.
-#	otc-taxonomy-parser $(OTT_DIR) --config=config -T > cleaned_ott/.raw_cleaned_ott.tre
+#	otc-taxonomy-parser $(OTT_DIR) --config=$(CONFIG_FILENAME) -T > cleaned_ott/.raw_cleaned_ott.tre
 #	mv cleaned_ott/.raw_cleaned_ott.tre cleaned_ott/cleaned_ott.tre
 
 $(PROPINQUITY_OUT_DIR)/cleaned_ott/cleaned_ott.json: $(PROPINQUITY_OUT_DIR)/cleaned_ott/cleaned_ott.tre
@@ -164,9 +162,9 @@ $(PROPINQUITY_OUT_DIR)/phylo_induced_taxonomy/taxonomy.tre : $(PROPINQUITY_OUT_D
 	ln -s $(PROPINQUITY_OUT_DIR)/exemplified_phylo/taxonomy.tre $(PROPINQUITY_OUT_DIR)/phylo_induced_taxonomy/taxonomy.tre
 
 # phylo_input holds the lists of study+tree pairs to be used during the supertree construction
-$(PROPINQUITY_OUT_DIR)/phylo_input/collections.txt: config
+$(PROPINQUITY_OUT_DIR)/phylo_input/collections.txt: $(CONFIG_FILENAME)
 	@if ! test -d $(PROPINQUITY_OUT_DIR)/phylo_input ; then mkdir -p $(PROPINQUITY_OUT_DIR)/phylo_input ; fi
-	bin/config_checker.py --config=config --property=synthesis.collections > $(PROPINQUITY_OUT_DIR)/phylo_input/.raw_collections.txt
+	bin/config_checker.py --config=$(CONFIG_FILENAME) --property=synthesis.collections > $(PROPINQUITY_OUT_DIR)/phylo_input/.raw_collections.txt
 	if ! diff \
 			$(PROPINQUITY_OUT_DIR)/phylo_input/collections.txt \
 			$(PROPINQUITY_OUT_DIR)/phylo_input/.raw_collections.txt 2>/dev/null ; \

--- a/Makefile.subproblems
+++ b/Makefile.subproblems
@@ -1,92 +1,157 @@
-ARTIFACTS += subproblems/subproblem-ids.txt \
-	  grafted_solution/grafted_solution.tre \
-	  grafted_solution_ottnames.tre \
-	  full_supertree/full_supertree.tre \
-	  subproblem_solutions/solution-ids.txt \
-	  subproblem_solutions/solution-degree-distributions.txt \
-	  labelled_supertree/labelled_supertree.tre \
-	  labelled_supertree/labelled_supertree_out_degree_distribution.txt \
-	  labelled_supertree/labelled_supertree_ottnames.tre \
-	  annotated_supertree/annotations.json
+ARTIFACTS += $(PROPINQUITY_OUT_DIR)/subproblems/subproblem-ids.txt \
+	  $(PROPINQUITY_OUT_DIR)/grafted_solution/grafted_solution.tre \
+	  $(PROPINQUITY_OUT_DIR)/grafted_solution_ottnames.tre \
+	  $(PROPINQUITY_OUT_DIR)/full_supertree/full_supertree.tre \
+	  $(PROPINQUITY_OUT_DIR)/subproblem_solutions/solution-ids.txt \
+	  $(PROPINQUITY_OUT_DIR)/subproblem_solutions/solution-degree-distributions.txt \
+	  $(PROPINQUITY_OUT_DIR)/labelled_supertree/labelled_supertree.tre \
+	  $(PROPINQUITY_OUT_DIR)/labelled_supertree/labelled_supertree_out_degree_distribution.txt \
+	  $(PROPINQUITY_OUT_DIR)/labelled_supertree/labelled_supertree_ottnames.tre \
+	  $(PROPINQUITY_OUT_DIR)/annotated_supertree/annotations.json
 
 
-subproblems/scratch/args.txt: exemplified_phylo/nonempty_trees.txt
-	cat exemplified_phylo/nonempty_trees.txt | sed -e 's:^:exemplified_phylo/:g' > subproblems/scratch/args.txt
+$(PROPINQUITY_OUT_DIR)/subproblems/scratch/args.txt: $(PROPINQUITY_OUT_DIR)/exemplified_phylo/nonempty_trees.txt
+	@if ! test -d $(PROPINQUITY_OUT_DIR)/subproblems/scratch ; then mkdir -p $(PROPINQUITY_OUT_DIR)/subproblems/scratch ; fi
+	cat $(PROPINQUITY_OUT_DIR)/exemplified_phylo/nonempty_trees.txt \
+	| sed -e "s:^:$(PROPINQUITY_OUT_DIR)/exemplified_phylo/:g" \
+	> $(PROPINQUITY_OUT_DIR)/subproblems/scratch/args.txt
 
 # Note that run-subproblem-finder.sh is odd in that the second arg is relative to the first arg.
 
-subproblems/dumped-subproblem-ids.txt: exemplified_phylo/taxonomy.tre subproblems/scratch/args.txt exemplified_phylo/nonempty_trees.txt
+$(PROPINQUITY_OUT_DIR)/subproblems/dumped-subproblem-ids.txt: $(PROPINQUITY_OUT_DIR)/exemplified_phylo/taxonomy.tre \
+															  $(PROPINQUITY_OUT_DIR)/subproblems/scratch/args.txt \
+															  $(PROPINQUITY_OUT_DIR)/exemplified_phylo/nonempty_trees.txt
+	@if ! test -d $(PROPINQUITY_OUT_DIR)/subproblems ; then mkdir -p $(PROPINQUITY_OUT_DIR)/subproblems ; fi
 	./bin/run-subproblem-finder.sh \
-	  subproblems/scratch \
+	  $(PROPINQUITY_OUT_DIR)/subproblems/scratch \
 	  ../dumped-subproblem-ids.txt \
-	  exemplified_phylo/taxonomy.tre \
-	  -fsubproblems/scratch/args.txt
+	  $(PROPINQUITY_OUT_DIR)/exemplified_phylo/taxonomy.tre \
+	  -f$(PROPINQUITY_OUT_DIR)/subproblems/scratch/args.txt
 
-subproblems/checksummed-subproblem-ids.txt: subproblems/dumped-subproblem-ids.txt
-	bash bin/checksum-tree-files.sh subproblems/scratch && cp subproblems/dumped-subproblem-ids.txt subproblems/checksummed-subproblem-ids.txt
+$(PROPINQUITY_OUT_DIR)/subproblems/checksummed-subproblem-ids.txt: $(PROPINQUITY_OUT_DIR)/subproblems/dumped-subproblem-ids.txt
+	@if ! test -d $(PROPINQUITY_OUT_DIR)/subproblems ; then mkdir -p $(PROPINQUITY_OUT_DIR)/subproblems ; fi
+	bash bin/checksum-tree-files.sh \
+		$(PROPINQUITY_OUT_DIR)/subproblems/scratch \
+	&& \
+		cp $(PROPINQUITY_OUT_DIR)/subproblems/dumped-subproblem-ids.txt \
+		   $(PROPINQUITY_OUT_DIR)/subproblems/checksummed-subproblem-ids.txt
 
-subproblems/subproblem-ids.txt: subproblems/checksummed-subproblem-ids.txt
-	bash bin/move-subproblem-if-differing.sh subproblems/scratch subproblems subproblems/checksummed-subproblem-ids.txt && cp subproblems/checksummed-subproblem-ids.txt subproblems/subproblem-ids.txt
+$(PROPINQUITY_OUT_DIR)/subproblems/subproblem-ids.txt: $(PROPINQUITY_OUT_DIR)/subproblems/checksummed-subproblem-ids.txt
+	@if ! test -d $(PROPINQUITY_OUT_DIR)/subproblems ; then mkdir -p $(PROPINQUITY_OUT_DIR)/subproblems ; fi
+	bash bin/move-subproblem-if-differing.sh \
+		$(PROPINQUITY_OUT_DIR)/subproblems/scratch \
+		$(PROPINQUITY_OUT_DIR)/subproblems \
+		$(PROPINQUITY_OUT_DIR)/subproblems/checksummed-subproblem-ids.txt \
+	&& \
+		cp $(PROPINQUITY_OUT_DIR)/subproblems/checksummed-subproblem-ids.txt \
+		   $(PROPINQUITY_OUT_DIR)/subproblems/subproblem-ids.txt
 
-subproblem_solutions/solution-ids.txt: subproblems/subproblem-ids.txt
+$(PROPINQUITY_OUT_DIR)/subproblem_solutions/solution-ids.txt: $(PROPINQUITY_OUT_DIR)/subproblems/subproblem-ids.txt
+	@if ! test -d $(PROPINQUITY_OUT_DIR)/subproblem_solutions ; then mkdir -p $(PROPINQUITY_OUT_DIR)/subproblem_solutions ; fi
 	for n in $$(cat subproblems/subproblem-ids.txt) ; do \
 		id=$${n%.tre} ; \
-		otc-solve-subproblem subproblems/$$n -n$${id} > subproblem_solutions/$${n} ; \
+		otc-solve-subproblem \
+			$(PROPINQUITY_OUT_DIR)/subproblems/$$n \
+			-n$${id} \
+			> $(PROPINQUITY_OUT_DIR)/subproblem_solutions/$${n} ; \
 	done ;
-	cp subproblems/subproblem-ids.txt subproblem_solutions/solution-ids.txt
+	cp $(PROPINQUITY_OUT_DIR)/subproblems/subproblem-ids.txt \
+	   $(PROPINQUITY_OUT_DIR)/subproblem_solutions/solution-ids.txt
 
 # This solution-degree-distributions.txt is just for documentation. The
 #	dependency should be all of the solutions, but it is easier to just
 #	make it depend on the next step in the procedure 
-subproblem_solutions/solution-degree-distributions.txt: grafted_solution/grafted_solution.tre
-	rm -f subproblem_solutions/.solution-degree-distributions.txt
-	for n in $$(cat subproblems/subproblem-ids.txt) ; do \
-		echo $${n} >> subproblem_solutions/.solution-degree-distributions.txt ;\
-		otc-degree-distribution subproblem_solutions/$${n} >> subproblem_solutions/.solution-degree-distributions.txt 2>/dev/null; \
+$(PROPINQUITY_OUT_DIR)/subproblem_solutions/solution-degree-distributions.txt: $(PROPINQUITY_OUT_DIR)/grafted_solution/grafted_solution.tre
+	@if ! test -d $(PROPINQUITY_OUT_DIR)/subproblem_solutions ; then mkdir -p $(PROPINQUITY_OUT_DIR)/subproblem_solutions ; fi
+	rm -f $(PROPINQUITY_OUT_DIR)/subproblem_solutions/.solution-degree-distributions.txt
+	for n in $$(cat $(PROPINQUITY_OUT_DIR)/subproblems/subproblem-ids.txt) ; do \
+		echo $${n} >> $(PROPINQUITY_OUT_DIR)/subproblem_solutions/.solution-degree-distributions.txt ;\
+		otc-degree-distribution \
+			$(PROPINQUITY_OUT_DIR)/subproblem_solutions/$${n} \
+			>> $(PROPINQUITY_OUT_DIR)/subproblem_solutions/.solution-degree-distributions.txt 2>/dev/null; \
 	done ;
-	mv subproblem_solutions/.solution-degree-distributions.txt subproblem_solutions/solution-degree-distributions.txt
+	mv $(PROPINQUITY_OUT_DIR)/subproblem_solutions/.solution-degree-distributions.txt \
+	   $(PROPINQUITY_OUT_DIR)/subproblem_solutions/solution-degree-distributions.txt
 
-grafted_solution/grafted_solution.tre: subproblem_solutions/solution-ids.txt
-	sed 's:^:subproblem_solutions/:' subproblem_solutions/solution-ids.txt > subproblem_solutions/paths.txt
-	otc-graft-solutions $$(cat subproblem_solutions/paths.txt) > grafted_solution/.grafted_solution.tre && \
-	mv grafted_solution/.grafted_solution.tre grafted_solution/grafted_solution.tre
-	rm subproblem_solutions/paths.txt
+$(PROPINQUITY_OUT_DIR)/grafted_solution/grafted_solution.tre: $(PROPINQUITY_OUT_DIR)/subproblem_solutions/solution-ids.txt
+	@if ! test -d $(PROPINQUITY_OUT_DIR)/grafted_solution ; then mkdir -p $(PROPINQUITY_OUT_DIR)/grafted_solution ; fi
+	sed "s:^:$(PROPINQUITY_OUT_DIR)/subproblem_solutions/:" \
+		$(PROPINQUITY_OUT_DIR)/subproblem_solutions/solution-ids.txt \
+		> $(PROPINQUITY_OUT_DIR)/subproblem_solutions/paths.txt
+	otc-graft-solutions $$(cat $(PROPINQUITY_OUT_DIR)/subproblem_solutions/paths.txt) \
+		> $(PROPINQUITY_OUT_DIR)/grafted_solution/.grafted_solution.tre && \
+	mv $(PROPINQUITY_OUT_DIR)/grafted_solution/.grafted_solution.tre \
+	   $(PROPINQUITY_OUT_DIR)/grafted_solution/grafted_solution.tre
+	rm $(PROPINQUITY_OUT_DIR)/subproblem_solutions/paths.txt
 
-grafted_solution/grafted_solution_ottnames.tre: grafted_solution/grafted_solution.tre
-	otc-relabel-tree grafted_solution/grafted_solution.tre --taxonomy=$(OTT_DIR) --format-tax="%N ott%I" --del-monotypic > grafted_solution/grafted_solution_ottnames.tre
+$(PROPINQUITY_OUT_DIR)/grafted_solution/grafted_solution_ottnames.tre: $(PROPINQUITY_OUT_DIR)/grafted_solution/grafted_solution.tre
+	@if ! test -d $(PROPINQUITY_OUT_DIR)/grafted_solution ; then mkdir -p $(PROPINQUITY_OUT_DIR)/grafted_solution ; fi
+	otc-relabel-tree \
+		$(PROPINQUITY_OUT_DIR)/grafted_solution/grafted_solution.tre \
+		--taxonomy=$(OTT_DIR) \
+		--format-tax="%N ott%I" \
+		--del-monotypic \
+		> $(PROPINQUITY_OUT_DIR)/grafted_solution/grafted_solution_ottnames.tre
 
-full_supertree/full_supertree.tre: grafted_solution/grafted_solution.tre cleaned_ott/cleaned_ott.tre
-	otc-unprune-solution grafted_solution/grafted_solution.tre cleaned_ott/cleaned_ott.tre > full_supertree/full_supertree.tre
+$(PROPINQUITY_OUT_DIR)/full_supertree/full_supertree.tre: $(PROPINQUITY_OUT_DIR)/grafted_solution/grafted_solution.tre \
+														  $(PROPINQUITY_OUT_DIR)/cleaned_ott/cleaned_ott.tre
+	@if ! test -d $(PROPINQUITY_OUT_DIR)/full_supertree ; then mkdir -p $(PROPINQUITY_OUT_DIR)/full_supertree ; fi
+	otc-unprune-solution \
+		$(PROPINQUITY_OUT_DIR)/grafted_solution/grafted_solution.tre \
+		$(PROPINQUITY_OUT_DIR)/cleaned_ott/cleaned_ott.tre \
+		> $(PROPINQUITY_OUT_DIR)/full_supertree/full_supertree.tre
 
-# No longer needed, since we now unprune and name unnamed nodes in one step
-#labelled_supertree/labelled_supertree.tre: full_supertree/full_supertree.tre
-#	otc-name-unnamed-nodes $^ > $@
+$(PROPINQUITY_OUT_DIR)/labelled_supertree/labelled_supertree.tre: $(PROPINQUITY_OUT_DIR)/grafted_solution/grafted_solution.tre \
+																  $(PROPINQUITY_OUT_DIR)/cleaned_ott/cleaned_ott.tre
+	@if ! test -d $(PROPINQUITY_OUT_DIR)/labelled_supertree ; then mkdir -p $(PROPINQUITY_OUT_DIR)/labelled_supertree ; fi
+	otc-unprune-solution-and-name-unnamed-nodes \
+		$(PROPINQUITY_OUT_DIR)/grafted_solution/grafted_solution.tre \
+		$(PROPINQUITY_OUT_DIR)/cleaned_ott/cleaned_ott.tre \
+		-j$(PROPINQUITY_OUT_DIR)/labelled_supertree/broken_taxa.json \
+		-s$(PROPINQUITY_OUT_DIR)/labelled_supertree/input_output_stats.json \
+		> $(PROPINQUITY_OUT_DIR)/labelled_supertree/labelled_supertree.tre 
 
-labelled_supertree/labelled_supertree.tre: grafted_solution/grafted_solution.tre cleaned_ott/cleaned_ott.tre
-	otc-unprune-solution-and-name-unnamed-nodes grafted_solution/grafted_solution.tre cleaned_ott/cleaned_ott.tre > labelled_supertree/labelled_supertree.tre -jlabelled_supertree/broken_taxa.json -slabelled_supertree/input_output_stats.json
+$(PROPINQUITY_OUT_DIR)/labelled_supertree/labelled_supertree_out_degree_distribution.txt: $(PROPINQUITY_OUT_DIR)/labelled_supertree/labelled_supertree.tre
+	@if ! test -d $(PROPINQUITY_OUT_DIR)/labelled_supertree ; then mkdir -p $(PROPINQUITY_OUT_DIR)/labelled_supertree ; fi
+	otc-degree-distribution \
+		$(PROPINQUITY_OUT_DIR)/labelled_supertree/labelled_supertree.tre \
+		> $(PROPINQUITY_OUT_DIR)/labelled_supertree/labelled_supertree_out_degree_distribution.txt
 
-labelled_supertree/labelled_supertree_out_degree_distribution.txt: labelled_supertree/labelled_supertree.tre
-	otc-degree-distribution labelled_supertree/labelled_supertree.tre > labelled_supertree/labelled_supertree_out_degree_distribution.txt
+$(PROPINQUITY_OUT_DIR)/labelled_supertree/labelled_supertree_ottnames.tre: $(PROPINQUITY_OUT_DIR)/labelled_supertree/labelled_supertree.tre
+	@if ! test -d $(PROPINQUITY_OUT_DIR)/labelled_supertree ; then mkdir -p $(PROPINQUITY_OUT_DIR)/labelled_supertree ; fi
+	otc-relabel-tree \
+		$(PROPINQUITY_OUT_DIR)/labelled_supertree/labelled_supertree.tre \
+		--taxonomy=$(OTT_DIR) \
+		--format-tax="%N ott%I" \
+		--del-monotypic \
+		> $(PROPINQUITY_OUT_DIR)/labelled_supertree/labelled_supertree_ottnames.tre
 
-labelled_supertree/labelled_supertree_ottnames.tre: labelled_supertree/labelled_supertree.tre
-	otc-relabel-tree labelled_supertree/labelled_supertree.tre --taxonomy=$(OTT_DIR) --format-tax="%N ott%I" --del-monotypic > labelled_supertree/labelled_supertree_ottnames.tre
-
-annotated_supertree/annotations.json: cleaned_ott/cleaned_ott.tre labelled_supertree/labelled_supertree.tre exemplified_phylo/nonempty_trees.txt
-	otc-annotate-synth cleaned_ott/cleaned_ott.tre labelled_supertree/labelled_supertree.tre $$(sed 's:^:exemplified_phylo/:' exemplified_phylo/nonempty_trees.txt) > annotated_supertree/preannotations1.json
+$(PROPINQUITY_OUT_DIR)/annotated_supertree/annotations.json: $(PROPINQUITY_OUT_DIR)/cleaned_ott/cleaned_ott.tre \
+															 $(PROPINQUITY_OUT_DIR)/labelled_supertree/labelled_supertree.tre \
+															 $(PROPINQUITY_OUT_DIR)/exemplified_phylo/nonempty_trees.txt
+	@if ! test -d $(PROPINQUITY_OUT_DIR)/annotated_supertree ; then mkdir -p $(PROPINQUITY_OUT_DIR)/annotated_supertree ; fi
+	otc-annotate-synth \
+		$(PROPINQUITY_OUT_DIR)/cleaned_ott/cleaned_ott.tre \
+		$(PROPINQUITY_OUT_DIR)/labelled_supertree/labelled_supertree.tre \
+		$$(sed "s:^:exemplified_phylo/:" $(PROPINQUITY_OUT_DIR)/exemplified_phylo/nonempty_trees.txt) \
+		> $(PROPINQUITY_OUT_DIR)/annotated_supertree/preannotations1.json
 	bin/add_subproblem_info_to_annotations.py \
-		subproblems/subproblem-ids.txt \
-		annotated_supertree/preannotations1.json \
-		annotated_supertree/annotations1.json
-	@rm annotated_supertree/preannotations1.json
-	bin/gen_attributes.py > annotated_supertree/annotations2.json
-	bin/merge-json.py annotated_supertree/annotations1.json annotated_supertree/annotations2.json > annotated_supertree/annotations.json
+		$(PROPINQUITY_OUT_DIR)/subproblems/subproblem-ids.txt \
+		$(PROPINQUITY_OUT_DIR)/annotated_supertree/preannotations1.json \
+		$(PROPINQUITY_OUT_DIR)/annotated_supertree/annotations1.json
+	@rm $(PROPINQUITY_OUT_DIR)/annotated_supertree/preannotations1.json
+	bin/gen_attributes.py > $(PROPINQUITY_OUT_DIR)/annotated_supertree/annotations2.json
+	bin/merge-json.py \
+		$(PROPINQUITY_OUT_DIR)/annotated_supertree/annotations1.json \
+		$(PROPINQUITY_OUT_DIR)/annotated_supertree/annotations2.json \
+		> $(PROPINQUITY_OUT_DIR)/annotated_supertree/annotations.json
 
 clean2:
-	rm -f subproblems/scratch/*.tre
-	rm -f subproblems/scratch/*.md5
-	rm -f subproblems/scratch/*.txt
-	rm -f subproblems/*.tre
-	rm -f subproblems/*.md5
-	rm -f subproblems/*.txt
-	rm -f subproblem_solutions/*.tre
-	rm -f annotated_supertree/*.json
+	rm -f $(PROPINQUITY_OUT_DIR)/subproblems/scratch/*.tre
+	rm -f $(PROPINQUITY_OUT_DIR)/subproblems/scratch/*.md5
+	rm -f $(PROPINQUITY_OUT_DIR)/subproblems/scratch/*.txt
+	rm -f $(PROPINQUITY_OUT_DIR)/subproblems/*.tre
+	rm -f $(PROPINQUITY_OUT_DIR)/subproblems/*.md5
+	rm -f $(PROPINQUITY_OUT_DIR)/subproblems/*.txt
+	rm -f $(PROPINQUITY_OUT_DIR)/subproblem_solutions/*.tre
+	rm -f $(PROPINQUITY_OUT_DIR)/annotated_supertree/*.json

--- a/Makefile.subproblems
+++ b/Makefile.subproblems
@@ -140,7 +140,7 @@ $(PROPINQUITY_OUT_DIR)/annotated_supertree/annotations.json: $(PROPINQUITY_OUT_D
 		$(PROPINQUITY_OUT_DIR)/annotated_supertree/preannotations1.json \
 		$(PROPINQUITY_OUT_DIR)/annotated_supertree/annotations1.json
 	@rm $(PROPINQUITY_OUT_DIR)/annotated_supertree/preannotations1.json
-	bin/gen_attributes.py $(PROPINQUITY_OUT_DIR) > $(PROPINQUITY_OUT_DIR)/annotated_supertree/annotations2.json
+	bin/gen_attributes.py --config=$(CONFIG_FILENAME) $(PROPINQUITY_OUT_DIR) > $(PROPINQUITY_OUT_DIR)/annotated_supertree/annotations2.json
 	bin/merge-json.py \
 		$(PROPINQUITY_OUT_DIR)/annotated_supertree/annotations1.json \
 		$(PROPINQUITY_OUT_DIR)/annotated_supertree/annotations2.json \

--- a/Makefile.subproblems
+++ b/Makefile.subproblems
@@ -48,7 +48,7 @@ $(PROPINQUITY_OUT_DIR)/subproblems/subproblem-ids.txt: $(PROPINQUITY_OUT_DIR)/su
 
 $(PROPINQUITY_OUT_DIR)/subproblem_solutions/solution-ids.txt: $(PROPINQUITY_OUT_DIR)/subproblems/subproblem-ids.txt
 	@if ! test -d $(PROPINQUITY_OUT_DIR)/subproblem_solutions ; then mkdir -p $(PROPINQUITY_OUT_DIR)/subproblem_solutions ; fi
-	for n in $$(cat subproblems/subproblem-ids.txt) ; do \
+	for n in $$(cat $(PROPINQUITY_OUT_DIR)/subproblems/subproblem-ids.txt) ; do \
 		id=$${n%.tre} ; \
 		otc-solve-subproblem \
 			$(PROPINQUITY_OUT_DIR)/subproblems/$$n \
@@ -133,14 +133,14 @@ $(PROPINQUITY_OUT_DIR)/annotated_supertree/annotations.json: $(PROPINQUITY_OUT_D
 	otc-annotate-synth \
 		$(PROPINQUITY_OUT_DIR)/cleaned_ott/cleaned_ott.tre \
 		$(PROPINQUITY_OUT_DIR)/labelled_supertree/labelled_supertree.tre \
-		$$(sed "s:^:exemplified_phylo/:" $(PROPINQUITY_OUT_DIR)/exemplified_phylo/nonempty_trees.txt) \
+		$$(sed "s:^:$(PROPINQUITY_OUT_DIR)/exemplified_phylo/:" $(PROPINQUITY_OUT_DIR)/exemplified_phylo/nonempty_trees.txt) \
 		> $(PROPINQUITY_OUT_DIR)/annotated_supertree/preannotations1.json
 	bin/add_subproblem_info_to_annotations.py \
 		$(PROPINQUITY_OUT_DIR)/subproblems/subproblem-ids.txt \
 		$(PROPINQUITY_OUT_DIR)/annotated_supertree/preannotations1.json \
 		$(PROPINQUITY_OUT_DIR)/annotated_supertree/annotations1.json
 	@rm $(PROPINQUITY_OUT_DIR)/annotated_supertree/preannotations1.json
-	bin/gen_attributes.py > $(PROPINQUITY_OUT_DIR)/annotated_supertree/annotations2.json
+	bin/gen_attributes.py $(PROPINQUITY_OUT_DIR) > $(PROPINQUITY_OUT_DIR)/annotated_supertree/annotations2.json
 	bin/merge-json.py \
 		$(PROPINQUITY_OUT_DIR)/annotated_supertree/annotations1.json \
 		$(PROPINQUITY_OUT_DIR)/annotated_supertree/annotations2.json \

--- a/bin/build_at_dir.sh
+++ b/bin/build_at_dir.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+d="$(dirname $0)"
+cf="$1"
+outd="$2"
+if ! test -f config
+then
+    echo "expecting the first argument to be a config file. ${cf} does not exist"
+    exit 1
+fi
+if test -f config
+then
+    echo 'file "config" exists. Moving it to config.BAK (overwriting that file if it exists)'
+    mv config confg.BAK
+fi
+echo "Copying ${cf} to config"
+cp "${cf}" config
+echo "Setting PROPINQUITY_OUT_DIR to ${outd}"
+export PROPINQUITY_OUT_DIR="${outd}"
+master="${d}/opentree_rebuild_from_latest.sh"
+echo "Calling ${master} ..."
+"${master}"

--- a/bin/build_at_dir.sh
+++ b/bin/build_at_dir.sh
@@ -2,18 +2,20 @@
 d="$(dirname $0)"
 cf="$1"
 outd="$2"
-if ! test -f config
+if ! test -f "${cf}"
 then
     echo "expecting the first argument to be a config file. ${cf} does not exist"
     exit 1
 fi
-if test -f config
+if ! test -d "${outd}"
 then
-    echo 'file "config" exists. Moving it to config.BAK (overwriting that file if it exists)'
-    mv config confg.BAK
+    mkdir "${outd}" || exit
 fi
-echo "Copying ${cf} to config"
-cp "${cf}" config
+if ! diff "${cf}" "${outd}/config" >/dev/null 2>&1
+then
+    echo "Copying ${cf} to ${outd}/config"
+    cp "${cf}" "${outd}/config" || exit
+fi
 echo "Setting PROPINQUITY_OUT_DIR to ${outd}"
 export PROPINQUITY_OUT_DIR="${outd}"
 master="${d}/opentree_rebuild_from_latest.sh"

--- a/bin/clean_at_dir.sh
+++ b/bin/clean_at_dir.sh
@@ -2,18 +2,20 @@
 d="$(dirname $0)"
 cf="$1"
 outd="$2"
-if ! test -f config
+if ! test -f "${cf}"
 then
     echo "expecting the first argument to be a config file. ${cf} does not exist"
     exit 1
 fi
-if test -f config
+if ! test -d "${outd}"
 then
-    echo 'file "config" exists. Moving it to config.BAK (overwriting that file if it exists)'
-    mv config confg.BAK
+    mkdir "${outd}" || exit
 fi
-echo "Copying ${cf} to config"
-cp "${cf}" config
+if ! diff "${cf}" "${outd}/config" >/dev/null 2>&1
+then
+    echo "Copying ${cf} to ${outd}/config"
+    cp "${cf}" "${outd}/config" || exit
+fi
 echo "Setting PROPINQUITY_OUT_DIR to ${outd}"
 export PROPINQUITY_OUT_DIR="${outd}"
 master="${d}/opentree_rebuild_from_latest.sh"

--- a/bin/clean_at_dir.sh
+++ b/bin/clean_at_dir.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+d="$(dirname $0)"
+cf="$1"
+outd="$2"
+if ! test -f config
+then
+    echo "expecting the first argument to be a config file. ${cf} does not exist"
+    exit 1
+fi
+if test -f config
+then
+    echo 'file "config" exists. Moving it to config.BAK (overwriting that file if it exists)'
+    mv config confg.BAK
+fi
+echo "Copying ${cf} to config"
+cp "${cf}" config
+echo "Setting PROPINQUITY_OUT_DIR to ${outd}"
+export PROPINQUITY_OUT_DIR="${outd}"
+master="${d}/opentree_rebuild_from_latest.sh"
+echo "Calling make clean ..."
+make clean

--- a/bin/document_outputs.py
+++ b/bin/document_outputs.py
@@ -349,6 +349,7 @@ class DocGen(object):
                          (render_assessments_index, 'assessments_index.pt', 'assessments/index'),
                         )
         for func, template_path, prefix in src_dest_list:
+            prefix = os.path.join(prefix_dir, prefix)
             html_path = prefix + '.html'
             json_path = prefix + '.json'
             t = self.templates[template_path]
@@ -371,7 +372,13 @@ if __name__ == '__main__':
                         type=str,
                         required=False,
                         help='filepath of the config file (default is "config")')
+    parser.add_argument('dir',
+                        default='.',
+                        type=str,
+                        nargs='?',
+                        help='prefix for inputs')
     args = parser.parse_args(sys.argv[1:])
+    prefix_dir = args.dir
     dg = DocGen(propinquity_dir, args.config)
     dg.render()
 

--- a/bin/document_outputs.py
+++ b/bin/document_outputs.py
@@ -203,10 +203,10 @@ def render_assessments_index(container, template, html_out, json_out):
     html_out.write(template(assessments=container.assessments))
 
 class DocGen(object):
-    def __init__(self, propinquity_dir, config_filepath):
-        self.top_output_dir = propinquity_dir #TEMP should be read from config
+    def __init__(self, propinquity_dir, supertree_output_dir, config_filepath):
+        self.top_output_dir = supertree_output_dir
         self.propinquity_dir = propinquity_dir
-        subprocess.call(['make', 'assessments/summary.json'])
+        subprocess.call(['make', os.path.join(self.top_output_dir, 'assessments', 'summary.json')])
         templates_dir = os.path.join(propinquity_dir, 'doc', 'templates')
         self.templates = PageTemplateLoader(templates_dir)
         self.config = get_runtime_configuration(config_filepath)
@@ -234,8 +234,8 @@ class DocGen(object):
         d = os.path.join(self.top_output_dir, 'labelled_supertree')
         p = 'labelled_supertree_out_degree_distribution.txt'
         lsodd = os.path.join(d, p)
-        subprocess.call(['make', 'labelled_supertree/' + p])
-        subprocess.call(['make', 'labelled_supertree/' + 'labelled_supertree_ottnames.tre'])
+        subprocess.call(['make', lsodd])
+        subprocess.call(['make', os.path.join(d, 'labelled_supertree_ottnames.tre')])
         assert(os.path.exists(lsodd))
         blob = Extensible()
         blob.unprune_stats = read_as_json(os.path.join(d, 'input_output_stats.json'))
@@ -244,7 +244,7 @@ class DocGen(object):
     def read_subproblem_solutions(self):
         d = os.path.join(self.top_output_dir, 'subproblem_solutions')
         sdd = os.path.join(d, 'solution-degree-distributions.txt')
-        subprocess.call(['make', 'subproblem_solutions/solution-degree-distributions.txt'])
+        subprocess.call(['make', sdd])
         assert(os.path.exists(sdd))
         blob = Extensible()
         blob.subproblem_num_leaves_num_internal_nodes = parse_subproblem_solutions_degree_dist(sdd)
@@ -300,7 +300,7 @@ class DocGen(object):
         for v in by_source_tree.values():
             v.sort()
         ptdd = os.path.join(d, 'pruned_taxonomy_degree_distribution.txt')
-        subprocess.call(['make', 'exemplified_phylo/pruned_taxonomy_degree_distribution.txt'])
+        subprocess.call(['make', ptdd])
         assert(os.path.exists(ptdd))
         ddlines = [i.split() for i in stripped_nonempty_lines(ptdd) if i.split()[0] == '0']
         assert(len(ddlines) == 1)
@@ -325,8 +325,8 @@ class DocGen(object):
         blob = Extensible()
         blob.directory = os.path.join(self.top_output_dir, 'phylo_snapshot')
         blob.git_shas_file = os.path.join(blob.directory, 'git_shas.txt')
-        subprocess.call(['make', 'phylo_snapshot/collections_git_shas.txt'])
         blob.collections_git_shas_file = os.path.join(blob.directory, 'collections_git_shas.txt')
+        subprocess.call(['make', blob.collections_git_shas_file])
         blob.collections_git_shas = stripped_nonempty_lines(blob.collections_git_shas_file)
         blob.git_shas = stripped_nonempty_lines(blob.git_shas_file)
         return blob
@@ -349,7 +349,6 @@ class DocGen(object):
                          (render_assessments_index, 'assessments_index.pt', 'assessments/index'),
                         )
         for func, template_path, prefix in src_dest_list:
-            prefix = os.path.join(prefix_dir, prefix)
             html_path = prefix + '.html'
             json_path = prefix + '.json'
             t = self.templates[template_path]
@@ -379,6 +378,6 @@ if __name__ == '__main__':
                         help='prefix for inputs')
     args = parser.parse_args(sys.argv[1:])
     prefix_dir = args.dir
-    dg = DocGen(propinquity_dir, args.config)
+    dg = DocGen(propinquity_dir, prefix_dir, args.config)
     dg.render()
 

--- a/bin/gen_attributes.py
+++ b/bin/gen_attributes.py
@@ -10,7 +10,7 @@ import os
 import codecs
 
 def num_studies():
-    with open('phylo_snapshot/concrete_rank_collection.json') as data_file:
+    with open(os.path.join(out_dir, 'phylo_snapshot/concrete_rank_collection.json')) as data_file:
         snapshot_data = json.load(data_file)
     studies = set()
     for study_tree_object in snapshot_data["decisions"]:
@@ -19,7 +19,7 @@ def num_studies():
     return len(studies)
 
 def num_trees():
-    with open('phylo_snapshot/concrete_rank_collection.json') as data_file:
+    with open(os.path.join(out_dir, 'phylo_snapshot/concrete_rank_collection.json')) as data_file:
         snapshot_data = json.load(data_file)
     trees = set()
     for study_tree_object in snapshot_data["decisions"]:
@@ -31,7 +31,7 @@ def num_trees():
 
 def extract_source_id_map():
     source_id_map = {}
-    with open('phylo_snapshot/concrete_rank_collection.json') as data_file:
+    with open(os.path.join(out_dir, 'phylo_snapshot/concrete_rank_collection.json')) as data_file:
         snapshot_data = json.load(data_file)
     for study_tree_object in snapshot_data["decisions"]:
         study_id = study_tree_object["studyID"]
@@ -104,8 +104,14 @@ if __name__ == '__main__':
                         type=str,
                         required=False,
                         help='directory containing ott files (e.g "taxonomy.tsv")')
+    parser.add_argument('dir',
+                        default='.',
+                        type=str,
+                        nargs='?',
+                        help='prefix for inputs')
     args = parser.parse_args(sys.argv[1:])
     ott_dir = args.ott_dir
+    out_dir = args.dir
     document = {}
     document["date_completed"] = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
     document["tree_id"] = "opentree4.1"

--- a/bin/make_at_dir.sh
+++ b/bin/make_at_dir.sh
@@ -2,18 +2,20 @@
 d="$(dirname $0)"
 cf="$1"
 outd="$2"
-if ! test -f config
+if ! test -f "${cf}"
 then
     echo "expecting the first argument to be a config file. ${cf} does not exist"
     exit 1
 fi
-if test -f config
+if ! test -d "${outd}"
 then
-    echo 'file "config" exists. Moving it to config.BAK (overwriting that file if it exists)'
-    mv config confg.BAK
+    mkdir "${outd}" || exit
 fi
-echo "Copying ${cf} to config"
-cp "${cf}" config
+if ! diff "${cf}" "${outd}/config" >/dev/null 2>&1
+then
+    echo "Copying ${cf} to ${outd}/config"
+    cp "${cf}" "${outd}/config" || exit
+fi
 echo "Setting PROPINQUITY_OUT_DIR to ${outd}"
 export PROPINQUITY_OUT_DIR="${outd}"
 master="${d}/opentree_rebuild_from_latest.sh"

--- a/bin/make_at_dir.sh
+++ b/bin/make_at_dir.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+d="$(dirname $0)"
+cf="$1"
+outd="$2"
+if ! test -f config
+then
+    echo "expecting the first argument to be a config file. ${cf} does not exist"
+    exit 1
+fi
+if test -f config
+then
+    echo 'file "config" exists. Moving it to config.BAK (overwriting that file if it exists)'
+    mv config confg.BAK
+fi
+echo "Copying ${cf} to config"
+cp "${cf}" config
+echo "Setting PROPINQUITY_OUT_DIR to ${outd}"
+export PROPINQUITY_OUT_DIR="${outd}"
+master="${d}/opentree_rebuild_from_latest.sh"
+echo "Calling make ..."
+make

--- a/bin/rebuild_from_latest.sh
+++ b/bin/rebuild_from_latest.sh
@@ -1,7 +1,12 @@
 #!/bin/sh
 # runs make clean, pulls study and collections from GitHub and
 # then builds the tree and docs 
-
+if test -z "$PROPINQUITY_OUT_DIR"
+then
+    echo "PROPINQUITY_OUT_DIR must be defined in env. Define it to . if you want to build in place"
+    exit 1
+fi
+mkdir -p "${PROPINQUITY_OUT_DIR}/logs" || exit
 orig_dir="$(pwd)"
 echo 'pulling the latest studies from the phylesystem shards'
 cd $(python bin/config_checker.py --config=config --property=opentree.phylesystem)
@@ -25,41 +30,53 @@ do
 done
 cd "${orig_dir}"
 
-echo 'Logs will show up in the propinquity/logs directory (in the event that something fails, check there).'
+echo "Logs will show up in the ${PROPINQUITY_OUT_DIR}/logs directory (in the event that something fails, check there)."
 echo 'cleaning previous outputs...'
-make clean >logs/log-of-make-clean.txt 2>logs/log-of-make-clean-err.txt
+make clean \
+    >${PROPINQUITY_OUT_DIR}/logs/log-of-make-clean.txt \
+    2>${PROPINQUITY_OUT_DIR}/logs/log-of-make-clean-err.txt || exit
 
 echo "Building the supertree"
 set -x
-rm -f logs/myeasylog.log
+rm -f ${PROPINQUITY_OUT_DIR}/logs/myeasylog.log
 
 echo 'cleaning the inputs...'
-rm -f logs/log-of-input-cleaning.txt
-rm -f logs/log-of-input-cleaning-err.txt
-time make exemplified_phylo/taxonomy.tre 2>logs/log-of-input-cleaning-err.txt > logs/log-of-input-cleaning.txt || exit
+rm -f ${PROPINQUITY_OUT_DIR}/logs/log-of-input-cleaning.txt
+rm -f ${PROPINQUITY_OUT_DIR}/logs/log-of-input-cleaning-err.txt
+time make ${PROPINQUITY_OUT_DIR}/exemplified_phylo/taxonomy.tre \
+    2>${PROPINQUITY_OUT_DIR}/logs/log-of-input-cleaning-err.txt \
+    > ${PROPINQUITY_OUT_DIR}/logs/log-of-input-cleaning.txt || exit
 
 
 echo 'creating the supertree...'
-rm -f logs/log-of-supertree.txt
-rm -f logs/log-of-supertree-err.txt
-time make labelled_supertree/labelled_supertree.tre 2>logs/log-of-supertree-err.txt > logs/log-of-supertree.txt || exit
+rm -f ${PROPINQUITY_OUT_DIR}/logs/log-of-supertree.txt
+rm -f ${PROPINQUITY_OUT_DIR}/logs/log-of-supertree-err.txt
+time make ${PROPINQUITY_OUT_DIR}/labelled_supertree/labelled_supertree.tre \
+    2>${PROPINQUITY_OUT_DIR}/logs/log-of-supertree-err.txt \
+    >${PROPINQUITY_OUT_DIR}/logs/log-of-supertree.txt || exit
 
 echo 'annotating the supertree...'
-rm -f logs/log-of-annotations.txt
-rm -f logs/log-of-annotations-err.txt
-time make annotated_supertree/annotations.json 2>logs/log-of-annotations-err.txt > logs/log-of-annotations.txt || exit
+rm -f ${PROPINQUITY_OUT_DIR}/logs/log-of-annotations.txt
+rm -f ${PROPINQUITY_OUT_DIR}/logs/log-of-annotations-err.txt
+time make ${PROPINQUITY_OUT_DIR}/annotated_supertree/annotations.json \
+    2>${PROPINQUITY_OUT_DIR}/logs/log-of-annotations-err.txt \
+    > ${PROPINQUITY_OUT_DIR}/logs/log-of-annotations.txt || exit
 
 echo 'running the assessments of the tree...'
-rm -f logs/log-of-assessments.txt
-rm -f logs/log-of-assessments-err.txt
-time make assessments/summary.json 2>logs/log-of-assessments-err.txt > logs/log-of-assessments.txt || exit
+rm -f ${PROPINQUITY_OUT_DIR}/logs/log-of-assessments.txt
+rm -f ${PROPINQUITY_OUT_DIR}/logs/log-of-assessments-err.txt
+time make ${PROPINQUITY_OUT_DIR}/assessments/summary.json \
+    2>${PROPINQUITY_OUT_DIR}/logs/log-of-assessments-err.txt \
+    > ${PROPINQUITY_OUT_DIR}/logs/log-of-assessments.txt || exit
 
 make check || exit
 
 echo 'creating documentation of the outputs...'
-rm -f logs/log-of-html.txt
-rm -f logs/log-of-html-err.txt
-time make html 2>logs/log-of-html-err.txt > logs/log-of-html.txt || exit
+rm -f ${PROPINQUITY_OUT_DIR}/logs/log-of-html.txt
+rm -f ${PROPINQUITY_OUT_DIR}/logs/log-of-html-err.txt
+time make html \
+    2>${PROPINQUITY_OUT_DIR}/logs/log-of-html-err.txt \
+    > ${PROPINQUITY_OUT_DIR}/logs/log-of-html.txt || exit
 
 
 echo 'Done'

--- a/bin/rebuild_from_latest.sh
+++ b/bin/rebuild_from_latest.sh
@@ -32,9 +32,14 @@ cd "${orig_dir}"
 
 echo "Logs will show up in the ${PROPINQUITY_OUT_DIR}/logs directory (in the event that something fails, check there)."
 echo 'cleaning previous outputs...'
-make clean \
+if ! make clean \
     >${PROPINQUITY_OUT_DIR}/logs/log-of-make-clean.txt \
-    2>${PROPINQUITY_OUT_DIR}/logs/log-of-make-clean-err.txt || exit
+    2>${PROPINQUITY_OUT_DIR}/logs/log-of-make-clean-err.txt
+then
+    cat ${PROPINQUITY_OUT_DIR}/logs/log-of-make-clean-err.txt
+    echo "Failed make clean"
+    exit 1
+fi
 
 echo "Building the supertree"
 set -x
@@ -43,40 +48,71 @@ rm -f ${PROPINQUITY_OUT_DIR}/logs/myeasylog.log
 echo 'cleaning the inputs...'
 rm -f ${PROPINQUITY_OUT_DIR}/logs/log-of-input-cleaning.txt
 rm -f ${PROPINQUITY_OUT_DIR}/logs/log-of-input-cleaning-err.txt
-time make ${PROPINQUITY_OUT_DIR}/exemplified_phylo/taxonomy.tre \
+if ! make ${PROPINQUITY_OUT_DIR}/exemplified_phylo/taxonomy.tre \
     2>${PROPINQUITY_OUT_DIR}/logs/log-of-input-cleaning-err.txt \
-    > ${PROPINQUITY_OUT_DIR}/logs/log-of-input-cleaning.txt || exit
+    > ${PROPINQUITY_OUT_DIR}/logs/log-of-input-cleaning.txt
+then
+    cat ${PROPINQUITY_OUT_DIR}/logs/log-of-input-cleaning-err.txt
+    echo "Failed cleaning of the input"
+    exit 1
+fi
 
 
 echo 'creating the supertree...'
 rm -f ${PROPINQUITY_OUT_DIR}/logs/log-of-supertree.txt
 rm -f ${PROPINQUITY_OUT_DIR}/logs/log-of-supertree-err.txt
-time make ${PROPINQUITY_OUT_DIR}/labelled_supertree/labelled_supertree.tre \
+if ! make ${PROPINQUITY_OUT_DIR}/labelled_supertree/labelled_supertree.tre \
     2>${PROPINQUITY_OUT_DIR}/logs/log-of-supertree-err.txt \
-    >${PROPINQUITY_OUT_DIR}/logs/log-of-supertree.txt || exit
+    >${PROPINQUITY_OUT_DIR}/logs/log-of-supertree.txt
+then
+    cat ${PROPINQUITY_OUT_DIR}/logs/log-of-supertree-err.txt
+    echo "Failed supertree step"
+    exit 1
+fi
 
 echo 'annotating the supertree...'
 rm -f ${PROPINQUITY_OUT_DIR}/logs/log-of-annotations.txt
 rm -f ${PROPINQUITY_OUT_DIR}/logs/log-of-annotations-err.txt
-time make ${PROPINQUITY_OUT_DIR}/annotated_supertree/annotations.json \
+if !  make ${PROPINQUITY_OUT_DIR}/annotated_supertree/annotations.json \
     2>${PROPINQUITY_OUT_DIR}/logs/log-of-annotations-err.txt \
-    > ${PROPINQUITY_OUT_DIR}/logs/log-of-annotations.txt || exit
+    > ${PROPINQUITY_OUT_DIR}/logs/log-of-annotations.txt
+then
+    cat ${PROPINQUITY_OUT_DIR}/logs/log-of-annotations-err.txt
+    echo "Failed annotations step"
+    exit 1
+fi
 
 echo 'running the assessments of the tree...'
 rm -f ${PROPINQUITY_OUT_DIR}/logs/log-of-assessments.txt
 rm -f ${PROPINQUITY_OUT_DIR}/logs/log-of-assessments-err.txt
-time make ${PROPINQUITY_OUT_DIR}/assessments/summary.json \
+if ! make ${PROPINQUITY_OUT_DIR}/assessments/summary.json \
     2>${PROPINQUITY_OUT_DIR}/logs/log-of-assessments-err.txt \
-    > ${PROPINQUITY_OUT_DIR}/logs/log-of-assessments.txt || exit
+    > ${PROPINQUITY_OUT_DIR}/logs/log-of-assessments.txt
+then
+    cat ${PROPINQUITY_OUT_DIR}/logs/log-of-assessments-err.txt
+    echo "Failed assessments step"
+    exit 1
+fi
 
-make check || exit
+if ! make check 2>${PROPINQUITY_OUT_DIR}/logs/log-of-make-check-err.txt \
+    > ${PROPINQUITY_OUT_DIR}/logs/log-of-make-check.txt
+then
+    cat ${PROPINQUITY_OUT_DIR}/logs/log-of-make-check-err.txt
+    echo "Failed assessments step"
+    exit 1
+fi 
 
 echo 'creating documentation of the outputs...'
 rm -f ${PROPINQUITY_OUT_DIR}/logs/log-of-html.txt
 rm -f ${PROPINQUITY_OUT_DIR}/logs/log-of-html-err.txt
-time make html \
+if ! make html \
     2>${PROPINQUITY_OUT_DIR}/logs/log-of-html-err.txt \
     > ${PROPINQUITY_OUT_DIR}/logs/log-of-html.txt || exit
+then
+    cat ${PROPINQUITY_OUT_DIR}/logs/log-of-html-err.txt
+    echo "Failed building of html step"
+    exit 1
+fi
 
 
 echo 'Done'

--- a/bin/run_assessments.py
+++ b/bin/run_assessments.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 from peyotl import read_as_json, write_as_json
-import subprocess
 import csv
 import sys
 import os


### PR DESCRIPTION
The env var `PROPINQUITY_OUT_DIR` now determines the output directory for the build, and the Makefiles expect there to be a `config` file in that directory.  See the new `bin/*at_dir.sh` scripts for examples that take 2 args: an output dir and a copy of the configuration file.
