### PR TITLE
Writing a report of contested taxa

### DIFF
--- a/Makefile.subproblems
+++ b/Makefile.subproblems
@@ -19,8 +19,6 @@ $(PROPINQUITY_OUT_DIR)/subproblems/scratch/args.txt: $(PROPINQUITY_OUT_DIR)/exem
 	| sed -e "s:^:$(PROPINQUITY_OUT_DIR)/exemplified_phylo/:g" \
 	> $(PROPINQUITY_OUT_DIR)/subproblems/scratch/args.txt
 
-# Note that run-subproblem-finder.sh is odd in that the second arg is relative to the first arg.
-
 $(PROPINQUITY_OUT_DIR)/subproblems/dumped-subproblem-ids.txt: $(PROPINQUITY_OUT_DIR)/exemplified_phylo/taxonomy.tre \
 															  $(PROPINQUITY_OUT_DIR)/subproblems/scratch/args.txt \
 															  $(PROPINQUITY_OUT_DIR)/exemplified_phylo/nonempty_trees.txt
@@ -28,6 +26,7 @@ $(PROPINQUITY_OUT_DIR)/subproblems/dumped-subproblem-ids.txt: $(PROPINQUITY_OUT_
 	./bin/run-subproblem-finder.sh \
 	  $(PROPINQUITY_OUT_DIR)/subproblems/scratch \
 	  $(PROPINQUITY_OUT_DIR)/subproblems/dumped-subproblem-ids.txt \
+	  $(PROPINQUITY_OUT_DIR)/subproblems/contesting-trees.json \
 	  $(PROPINQUITY_OUT_DIR)/exemplified_phylo/taxonomy.tre \
 	  -f$(PROPINQUITY_OUT_DIR)/subproblems/scratch/args.txt
 

--- a/bin/run-subproblem-finder.sh
+++ b/bin/run-subproblem-finder.sh
@@ -4,9 +4,14 @@
 #   2. a filepath to store the .tre filenames for all of the tree files created by the
 #       the decomposition. This will only be created if the decomposition exits without error.
 #       if a relative path, it should be relative to the export dir!!
+#   3. a filepath to JSON representation of contested OTT ID to list of trees that contest that
+#       that taxon.
+#       if a relative path, it should be relative to the export dir!!
 exportdir="$1"
 shift
 dumpedidfile="$1"
+shift
+contestingtreesfile="$1"
 shift
 set -x
 if test -z $exportdir
@@ -19,6 +24,11 @@ then
     echo "expecting the second argument to be a filepath (absolute or relative to the export directory) for the subproblem IDs."
     exit 1
 fi
+if test -z $contestingtreesfile
+then
+    echo "expecting the third argument to be a filepath (absolute or relative to the export directory) for a JSON repr of the contesting trees for each taxon."
+    exit 1
+fi
 
 if test -d "${exportdir}"
 then
@@ -26,5 +36,5 @@ then
 else
     mkdir "${exportdir}" || exit
 fi
-otc-uncontested-decompose -e"${exportdir}" -x"${dumpedidfile}" $@ || exit
+otc-uncontested-decompose -e"${exportdir}" -x"${dumpedidfile}" -c"${contestingtreesfile}" $@ || exit
 

--- a/doc/templates/subproblems_index.pt
+++ b/doc/templates/subproblems_index.pt
@@ -40,5 +40,26 @@ The taxonomy overlaps with every subproblem.</p>
         <td>${', '.join(inp_sub_l[1])}</td>
     </tr>
 </table>
+<p>The ${len(subproblems.contested_taxa)} contested taxa follow. For each tree, the 
+For each taxon, the "parent nodes" listed refers to a internal nodes each of which has
+at least 1 child that belongs entirely to the taxon
+and at least one descendant that does not belong in the taxon. If the OTT Id were
+not contested, there would only be one internal node that fit those criterion, but 
+in contested taxa for there are multiple.</p>
+<ul>
+    <li tal:repeat="ott_all_trees subproblems.contested_taxa.items()">
+      <a href="https://tree.opentreeoflife.org/taxonomy/browse?id=${ott_all_trees[0]}">${ott_all_trees[0]}</a> contested by:
+      <ul>
+        <li tal:repeat="tree_bundle ott_all_trees[1]">
+        <a href="https://tree.opentreeoflife.org/curator/study/view/${tree_bundle['study_id']}/?tab=trees&tree=${tree_bundle['tree_id']}" target="_blank">tree "${tree_bundle['tree_id']}"" of study "${tree_bundle['study_id']}"</a>
+            <ul>
+                <li tal:repeat="node_inf tree_bundle.conflicting_nodes">
+                Parent node ID = ${node_inf['parent'].get('node_id', node_inf['parent']['label'])}
+                </li>
+            </ul>
+        </li>
+      </ul>
+    </li>
+</ul>
 </div>
 </html>

--- a/subproblems/README.md
+++ b/subproblems/README.md
@@ -10,6 +10,19 @@ The artifacts are the subproblems and some related files
  * `ott#####.md5`: MD5 digests for `ott#####.tre` and `ott#####.md5`
  * `subproblem-ids.txt`: The list of subproblem files.
  * `checksummed-subproblem-ids.txt`: ???
+ * `contesting-trees.json`: A JSON representation of a summary of
+ the contested taxa. The JSON object serialized has keys that correpsond
+ to each contested taxon. For the each taxon key there is an object that
+ maps the tree file (study@tree id form) to list of the node info for
+ the parts of the tree that conflict with the taxon. This node info consists of an object with a "parent" field that identifies the parental
+ node, and a list of children of that parent (in a "children_from_taxon"
+ attribute) that identifies all of the children of that parent that consist
+ only of members of this taxon.  The parents included are nodes that have
+ some children that are consist of only members of the taxon and some 
+ children that have members that are excluded from the taxon. If the tree 
+ did not contest with the taxon, there would only be one such parent.
+ Because this file only reports conflicting trees, there should be at least
+ 2 node info object for each tree.
 
 Produced by `otc-uncontested-decompose`.
 


### PR DESCRIPTION
This entails using a new flag to otc-uncontested-decompose
to get report on the nodes in a trees that contest a taxon
and then writing the documentation of this information to
subproblems/index.html when using the `make html` target.
